### PR TITLE
[KLC-1536] Update deploy scripts to use operator CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,6 +1344,7 @@ name = "max-bridged-amount-module"
 version = "0.0.0"
 dependencies = [
  "klever-sc",
+ "klever-sc-modules",
  "klever-sc-scenario",
 ]
 
@@ -2211,6 +2212,7 @@ version = "0.0.0"
 dependencies = [
  "fee-estimator-module",
  "klever-sc",
+ "klever-sc-modules",
  "klever-sc-scenario",
 ]
 

--- a/bridged-tokens-wrapper/sc-config.toml
+++ b/bridged-tokens-wrapper/sc-config.toml
@@ -1,4 +1,9 @@
 [settings]
+main = "bridged-tokens-wrapper"
+
+# the only purpose of this config is to specify the allocator
+[contracts.bridged-tokens-wrapper]
+allocator = "static64k"
 
 [[proxy]]
 path = "../multi-transfer-esdt/src/bridged_tokens_wrapper_proxy.rs"

--- a/bridged-tokens-wrapper/src/kda_safe_proxy.rs
+++ b/bridged-tokens-wrapper/src/kda_safe_proxy.rs
@@ -771,6 +771,54 @@ where
             .raw_call("isPaused")
             .original_result()
     }
+
+    pub fn is_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, bool> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("isAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn add_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("addAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn remove_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("removeAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn admins(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, MultiValueEncoded<Env::Api, ManagedAddress<Env::Api>>> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getAdmins")
+            .original_result()
+    }
 }
 
 #[type_abi]

--- a/bridged-tokens-wrapper/wasm/Cargo.lock
+++ b/bridged-tokens-wrapper/wasm/Cargo.lock
@@ -197,6 +197,7 @@ version = "0.0.0"
 dependencies = [
  "fee-estimator-module",
  "klever-sc",
+ "klever-sc-modules",
 ]
 
 [[package]]

--- a/bridged-tokens-wrapper/wasm/src/lib.rs
+++ b/bridged-tokens-wrapper/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 
-klever_sc_wasm_adapter::allocator!();
+klever_sc_wasm_adapter::allocator!(static64k);
 klever_sc_wasm_adapter::panic_handler!();
 
 klever_sc_wasm_adapter::endpoints! {

--- a/common/max-bridged-amount-module/Cargo.toml
+++ b/common/max-bridged-amount-module/Cargo.toml
@@ -11,3 +11,7 @@ path="../../../klever-vm-sdk-rs-internal/framework/base"
 [dev-dependencies.klever-sc-scenario]
 version = "0.44.0"
 path="../../../klever-vm-sdk-rs-internal/framework/scenario"
+
+[dependencies.klever-sc-modules]
+version = "0.44.0"
+path="../../../klever-vm-sdk-rs-internal/contracts/modules"

--- a/common/max-bridged-amount-module/src/lib.rs
+++ b/common/max-bridged-amount-module/src/lib.rs
@@ -3,8 +3,8 @@
 use klever_sc::imports::*;
 
 #[klever_sc::module]
-pub trait MaxBridgedAmountModule {
-    #[only_owner]
+pub trait MaxBridgedAmountModule: klever_sc_modules::only_admin::OnlyAdminModule {
+    #[only_admin]
     #[endpoint(setMaxBridgedAmount)]
     fn set_max_bridged_amount(&self, token_id: TokenIdentifier, max_amount: BigUint) {
         self.max_bridged_amount(&token_id).set(&max_amount);

--- a/common/token-module/Cargo.toml
+++ b/common/token-module/Cargo.toml
@@ -14,3 +14,7 @@ path="../../../klever-vm-sdk-rs-internal/framework/base"
 [dev-dependencies.klever-sc-scenario]
 version = "0.44.0"
 path="../../../klever-vm-sdk-rs-internal/framework/scenario"
+
+[dependencies.klever-sc-modules]
+version = "0.44.0"
+path="../../../klever-vm-sdk-rs-internal/contracts/modules"

--- a/common/token-module/src/lib.rs
+++ b/common/token-module/src/lib.rs
@@ -14,13 +14,15 @@ pub struct AddressPercentagePair<M: ManagedTypeApi> {
 }
 
 #[klever_sc::module]
-pub trait TokenModule: fee_estimator_module::FeeEstimatorModule {
+pub trait TokenModule: fee_estimator_module::FeeEstimatorModule 
+    + klever_sc_modules::only_admin::OnlyAdminModule
+{
     // endpoints - owner-only
 
     /// Distributes the accumulated fees to the given addresses.
     /// Expected arguments are pairs of (address, percentage),
     /// where percentages must add up to the PERCENTAGE_TOTAL constant
-    #[only_owner]
+    #[only_admin]
     #[endpoint(distributeFees)]
     fn distribute_fees(
         &self,
@@ -64,7 +66,7 @@ pub trait TokenModule: fee_estimator_module::FeeEstimatorModule {
         }
     }
 
-    #[only_owner]
+    #[only_admin]
     #[payable("*")]
     #[endpoint(addTokenToWhitelist)]
     fn add_token_to_whitelist(
@@ -116,7 +118,7 @@ pub trait TokenModule: fee_estimator_module::FeeEstimatorModule {
         }
     }
 
-    #[only_owner]
+    #[only_admin]
     #[endpoint(removeTokenFromWhitelist)]
     fn remove_token_from_whitelist(&self, token_id: TokenIdentifier) {
         self.token_ticker(&token_id).clear();
@@ -177,7 +179,7 @@ pub trait TokenModule: fee_estimator_module::FeeEstimatorModule {
         true
     }
 
-    #[only_owner]
+    #[only_admin]
     #[payable("*")]
     #[endpoint(initSupply)]
     fn init_supply(&self, token_id: &TokenIdentifier, amount: &BigUint) {
@@ -200,7 +202,7 @@ pub trait TokenModule: fee_estimator_module::FeeEstimatorModule {
         });
     }
 
-    #[only_owner]
+    #[only_admin]
     #[endpoint(initSupplyMintBurn)]
     fn init_supply_mint_burn(
         &self,
@@ -256,7 +258,7 @@ pub trait TokenModule: fee_estimator_module::FeeEstimatorModule {
         );
     }
 
-    #[only_owner]
+    #[only_admin]
     #[endpoint(setMultiTransferContractAddress)]
     fn set_multi_transfer_contract_address(&self, opt_new_address: OptionalValue<ManagedAddress>) {
         match opt_new_address {

--- a/kda-safe/src/kda_safe.rs
+++ b/kda-safe/src/kda_safe.rs
@@ -30,7 +30,8 @@ pub trait KDASafe:
     + token_module::TokenModule
     + tx_batch_module::TxBatchModule
     + max_bridged_amount_module::MaxBridgedAmountModule
-    + klever_sc_modules::pause::PauseModule
+    + klever_sc_modules::only_admin::OnlyAdminModule
+    + klever_sc_modules::pause_admin::PauseAdminModule
 {
     /// fee_estimator_contract_address - The address of a Price Aggregator contract,
     /// which will get the price of token A in token B
@@ -103,7 +104,7 @@ pub trait KDASafe:
     ///
     /// Only TransactionStatus::Executed (3) and TransactionStatus::Rejected (4) values are allowed.
     /// Number of provided statuses must be equal to number of transactions in the batch.
-    #[only_owner]
+    #[only_admin]
     #[endpoint(setTransactionBatchStatus)]
     fn set_transaction_batch_status(
         &self,
@@ -376,7 +377,7 @@ pub trait KDASafe:
         KdaTokenPayment::new(token_id, 0, refund_amount)
     }
 
-    #[only_owner]
+    #[only_admin]
     #[endpoint(setBridgedTokensWrapperAddress)]
     fn set_bridged_tokens_wrapper_contract_address(
         &self,
@@ -394,7 +395,7 @@ pub trait KDASafe:
         }
     }
 
-    #[only_owner]
+    #[only_admin]
     #[endpoint(withdrawRefundFeesForEthereum)]
     fn withdraw_refund_fees_for_ethereum(
         &self,
@@ -414,7 +415,7 @@ pub trait KDASafe:
         refund_fees_for_ethereum_mapper.set(BigUint::zero());
     }
 
-    #[only_owner]
+    #[only_admin]
     #[endpoint(withdrawTransactionFees)]
     fn withdraw_transaction_fees(&self, token_id: TokenIdentifier, multisig_owner: ManagedAddress) {
         let accumulated_transaction_fees_mapper = self.accumulated_transaction_fees(&token_id);

--- a/kda-safe/wasm/Cargo.lock
+++ b/kda-safe/wasm/Cargo.lock
@@ -195,6 +195,7 @@ name = "max-bridged-amount-module"
 version = "0.0.0"
 dependencies = [
  "klever-sc",
+ "klever-sc-modules",
 ]
 
 [[package]]
@@ -318,6 +319,7 @@ version = "0.0.0"
 dependencies = [
  "fee-estimator-module",
  "klever-sc",
+ "klever-sc-modules",
 ]
 
 [[package]]

--- a/kda-safe/wasm/src/lib.rs
+++ b/kda-safe/wasm/src/lib.rs
@@ -5,8 +5,8 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           49
-// Total number of exported functions:  51
+// Endpoints:                           53
+// Total number of exported functions:  55
 
 #![no_std]
 
@@ -64,6 +64,10 @@ klever_sc_wasm_adapter::endpoints! {
         getLastBatchId => last_batch_id
         setMaxBridgedAmount => set_max_bridged_amount
         getMaxBridgedAmount => max_bridged_amount
+        isAdmin => is_admin
+        addAdmin => add_admin
+        removeAdmin => remove_admin
+        getAdmins => admins
         pause => pause_endpoint
         unpause => unpause_endpoint
         isPaused => paused_status

--- a/multi-transfer-kda/sc-config.toml
+++ b/multi-transfer-kda/sc-config.toml
@@ -1,4 +1,10 @@
 [settings]
+main = "multi-transfer-kda"
+
+# the only purpose of this config is to specify the allocator
+[contracts.multi-transfer-kda]
+allocator = "static64k"
+
 
 [[proxy]]
 path = "../multisig/src/multi_transfer_kda_proxy.rs"

--- a/multi-transfer-kda/src/kda_safe_proxy.rs
+++ b/multi-transfer-kda/src/kda_safe_proxy.rs
@@ -771,6 +771,54 @@ where
             .raw_call("isPaused")
             .original_result()
     }
+
+    pub fn is_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, bool> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("isAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn add_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("addAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn remove_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("removeAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn admins(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, MultiValueEncoded<Env::Api, ManagedAddress<Env::Api>>> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getAdmins")
+            .original_result()
+    }
 }
 
 #[type_abi]

--- a/multi-transfer-kda/src/lib.rs
+++ b/multi-transfer-kda/src/lib.rs
@@ -3,6 +3,7 @@
 use klever_sc::{imports::*, storage::StorageKey};
 
 use eth_address::EthAddress;
+use klever_sc_modules::only_admin;
 use transaction::{EthTransaction, PaymentsVec, Transaction, TxNonce};
 
 pub mod bridged_tokens_wrapper_proxy;
@@ -16,6 +17,7 @@ const CHAIN_SPECIFIC_TO_UNIVERSAL_TOKEN_MAPPING: &[u8] = b"chainSpecificToUniver
 #[klever_sc::contract]
 pub trait MultiTransferKda:
     tx_batch_module::TxBatchModule + max_bridged_amount_module::MaxBridgedAmountModule
+    + only_admin::OnlyAdminModule
 {
     #[init]
     fn init(&self) {
@@ -39,7 +41,7 @@ pub trait MultiTransferKda:
         self.last_batch_id().set_if_empty(1);
     }
 
-    #[only_owner]
+    #[only_admin]
     #[endpoint(batchTransferKdaToken)]
     fn batch_transfer_kda_token(
         &self,
@@ -99,7 +101,7 @@ pub trait MultiTransferKda:
         self.add_multiple_tx_to_batch(&refund_tx_list);
     }
 
-    #[only_owner]
+    #[only_admin]
     #[endpoint(moveRefundBatchToSafe)]
     fn move_refund_batch_to_safe(&self) {
         let opt_current_batch = self.get_first_batch_any_status();
@@ -133,7 +135,7 @@ pub trait MultiTransferKda:
         }
     }
 
-    #[only_owner]
+    #[only_admin]
     #[endpoint(setWrappingContractAddress)]
     fn set_wrapping_contract_address(&self, opt_new_address: OptionalValue<ManagedAddress>) {
         match opt_new_address {
@@ -149,7 +151,7 @@ pub trait MultiTransferKda:
         }
     }
 
-    #[only_owner]
+    #[only_admin]
     #[endpoint(addUnprocessedRefundTxToBatch)]
     fn add_unprocessed_refund_tx_to_batch(&self, tx_id: u64) {
         let refund_tx = self.unprocessed_refund_txs(tx_id).get();
@@ -160,7 +162,7 @@ pub trait MultiTransferKda:
         self.unprocessed_refund_txs(tx_id).clear();
     }
 
-    #[only_owner]
+    #[only_admin]
     #[endpoint(setKdaSafeContractAddress)]
     fn set_kda_safe_contract_address(&self, opt_new_address: OptionalValue<ManagedAddress>) {
         match opt_new_address {

--- a/multi-transfer-kda/src/multi_transfer_proxy.rs
+++ b/multi-transfer-kda/src/multi_transfer_proxy.rs
@@ -279,4 +279,52 @@ where
             .argument(&token_id)
             .original_result()
     }
+
+    pub fn is_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, bool> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("isAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn add_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("addAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn remove_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("removeAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn admins(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, MultiValueEncoded<Env::Api, ManagedAddress<Env::Api>>> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getAdmins")
+            .original_result()
+    }
 }

--- a/multi-transfer-kda/wasm/Cargo.lock
+++ b/multi-transfer-kda/wasm/Cargo.lock
@@ -204,6 +204,7 @@ name = "max-bridged-amount-module"
 version = "0.0.0"
 dependencies = [
  "klever-sc",
+ "klever-sc-modules",
 ]
 
 [[package]]
@@ -350,6 +351,7 @@ version = "0.0.0"
 dependencies = [
  "fee-estimator-module",
  "klever-sc",
+ "klever-sc-modules",
 ]
 
 [[package]]

--- a/multi-transfer-kda/wasm/src/lib.rs
+++ b/multi-transfer-kda/wasm/src/lib.rs
@@ -5,12 +5,12 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           17
-// Total number of exported functions:  19
+// Endpoints:                           21
+// Total number of exported functions:  23
 
 #![no_std]
 
-klever_sc_wasm_adapter::allocator!();
+klever_sc_wasm_adapter::allocator!(static64k);
 klever_sc_wasm_adapter::panic_handler!();
 
 klever_sc_wasm_adapter::endpoints! {
@@ -35,5 +35,9 @@ klever_sc_wasm_adapter::endpoints! {
         getLastBatchId => last_batch_id
         setMaxBridgedAmount => set_max_bridged_amount
         getMaxBridgedAmount => max_bridged_amount
+        isAdmin => is_admin
+        addAdmin => add_admin
+        removeAdmin => remove_admin
+        getAdmins => admins
     )
 }

--- a/multisig/interaction/config/aggregator-snippets.sh
+++ b/multisig/interaction/config/aggregator-snippets.sh
@@ -44,17 +44,17 @@ submitAggregatorBatch() {
 
     CURRENT_TIME=$(date +%s)
     operator sc invoke ${AGGREGATOR} submitBatch --key-file=${ORACLE_WALLET0} \
-    --args String:GWEI String:${CHAIN_SPECIFIC_TOKEN_TICKER} u64:${CURRENT_TIME} n:${FEE} u8:0 \
+    --args String:GWEI --args String:${CHAIN_SPECIFIC_TOKEN_TICKER} --args u64:${CURRENT_TIME} --args n:${FEE} --args u8:0 \
     --await --sign --node ${PROXY}
 
     CURRENT_TIME=$(date +%s)
     operator sc invoke ${AGGREGATOR} submitBatch --key-file=${ORACLE_WALLET1} \
-    --args String:GWEI String:${CHAIN_SPECIFIC_TOKEN_TICKER} u64:${CURRENT_TIME} n:${FEE} u8:0 \
+    --args String:GWEI --args String:${CHAIN_SPECIFIC_TOKEN_TICKER} --args u64:${CURRENT_TIME} --args n:${FEE} --args u8:0 \
     --await --sign --node ${PROXY}
 
     CURRENT_TIME=$(date +%s)
     operator sc invoke ${AGGREGATOR} submitBatch --key-file=${ORACLE_WALLET2} \
-    --args String:GWEI String:${CHAIN_SPECIFIC_TOKEN_TICKER} u64:${CURRENT_TIME} n:${FEE} u8:0 \
+    --args String:GWEI --args String:${CHAIN_SPECIFIC_TOKEN_TICKER} --args u64:${CURRENT_TIME} --args n:${FEE} --args u8:0 \
     --await --sign --node ${PROXY}
 }
 
@@ -62,7 +62,7 @@ setPairDecimals() {
     CHECK_VARIABLES AGGREGATOR
 
     operator sc invoke ${AGGREGATOR} setPairDecimals --key-file=${ALICE} \
-    --args String:GWEI String:${CHAIN_SPECIFIC_TOKEN_TICKER} u8:0 \
+    --args String:GWEI --args String:${CHAIN_SPECIFIC_TOKEN_TICKER} --args u8:0 \
     --await --sign --node ${PROXY}
 }
 
@@ -86,4 +86,7 @@ aggregator-upgrade() {
     operator sc upgrade ${AGGREGATOR} --key-file=${ALICE} \
     --wasm ${AGGREGATOR_WASM} \
     --await --sign --node ${PROXY}
+    
+    echo ""
+    echo "Price aggregator upgraded successfully at address: ${AGGREGATOR}"
 }

--- a/multisig/interaction/config/aggregator-snippets.sh
+++ b/multisig/interaction/config/aggregator-snippets.sh
@@ -1,41 +1,39 @@
 deployAggregator() {
     CHECK_VARIABLES AGGREGATOR_WASM CHAIN_SPECIFIC_TOKEN ORACLE_ADDR_0 ORACLE_ADDR_1 ORACLE_ADDR_2
 
-    STAKE=$(echo "$ORACLE_REQUIRED_STAKE*10^18" | bc)
-    mxpy contract deploy --bytecode=${AGGREGATOR_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=100000000 --arguments str:EGLD ${STAKE} 1 2 3 \
-    ${ORACLE_ADDR_0} ${ORACLE_ADDR_1} ${ORACLE_ADDR_2} \
-    --send --outfile=deploy-price-agregator-testnet.interaction.json --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    STAKE=$(echo "$ORACLE_REQUIRED_STAKE*10^6" | bc)
 
-    TRANSACTION=$(mxpy data parse --file="./deploy-price-agregator-testnet.interaction.json" --expression="data['emittedTransactionHash']")
-    ADDRESS=$(mxpy data parse --file="./deploy-price-agregator-testnet.interaction.json" --expression="data['contractAddress']")
+    SC_RESULT=$(eval operator sc create --key-file=${ALICE} --wasm ${AGGREGATOR_WASM} \
+    --args String:KLV --args u64:${STAKE} --args u64:1 --args u64:2 --args u64:3 \
+    --args A:${ORACLE_ADDR_0} --args A:${ORACLE_ADDR_1} --args A:${ORACLE_ADDR_2} \
+    --await --result-only --sign --node ${PROXY})
 
-    mxpy data store --key=address-testnet-safe --value=${ADDRESS}
-    mxpy data store --key=deployTransaction-testnet --value=${TRANSACTION}
+    check_result ${SC_RESULT}
 
+    CONTRACT_ADDRESS=$(jq '.logs.events[] | select(.identifier=="SCDeploy") | .address' <<< "${SC_RESULT}")
+    CONTRACT_ADDRESS=$(echo ${CONTRACT_ADDRESS} | tr -d '"')
+    
     echo ""
-    echo "Price agregator: ${ADDRESS}"
-    update-config AGGREGATOR ${ADDRESS}
+    echo "Price agregator: ${CONTRACT_ADDRESS}"
+    update-config AGGREGATOR ${CONTRACT_ADDRESS}
 }
 
 stakeOracles() {
     CHECK_VARIABLES AGGREGATOR
 
-    STAKE=$(echo "$ORACLE_REQUIRED_STAKE*10^18" | bc)
+    STAKE=$(echo "$ORACLE_REQUIRED_STAKE*10^6" | bc)
     echo "---------------------------------------------------------"
-    mxpy --verbose contract call ${AGGREGATOR} --recall-nonce --pem=${ORACLE_WALLET0} \
-    --gas-limit=35000000 --function="stake" --value=${STAKE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
-    echo "---------------------------------------------------------"
-    echo "---------------------------------------------------------"
-    mxpy --verbose contract call ${AGGREGATOR} --recall-nonce --pem=${ORACLE_WALLET1} \
-    --gas-limit=35000000 --function="stake" --value=${STAKE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${AGGREGATOR} stake --key-file=${ORACLE_WALLET0} \
+    --values KLV=${STAKE} --await --sign --node ${PROXY}
+
     echo "---------------------------------------------------------"
     echo "---------------------------------------------------------"
-    mxpy --verbose contract call ${AGGREGATOR} --recall-nonce --pem=${ORACLE_WALLET2} \
-    --gas-limit=35000000 --function="stake" --value=${STAKE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${AGGREGATOR} stake --key-file=${ORACLE_WALLET1} \
+    --values KLV=${STAKE} --await --sign --node ${PROXY}
+    echo "---------------------------------------------------------"
+    echo "---------------------------------------------------------"
+    operator sc invoke ${AGGREGATOR} stake --key-file=${ORACLE_WALLET2} \
+    --values KLV=${STAKE} --await --sign --node ${PROXY}
     echo "---------------------------------------------------------"
 }
 
@@ -45,61 +43,47 @@ submitAggregatorBatch() {
     FEE=$(echo "scale=0; $FEE_AMOUNT*10^$NR_DECIMALS_CHAIN_SPECIFIC/1" | bc)
 
     CURRENT_TIME=$(date +%s)
-    mxpy --verbose contract call ${AGGREGATOR} --recall-nonce --pem=${ORACLE_WALLET0} \
-    --gas-limit=15000000 --function="submitBatch" \
-    --arguments str:GWEI str:${CHAIN_SPECIFIC_TOKEN_TICKER} ${CURRENT_TIME} ${FEE} 0 \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    operator sc invoke ${AGGREGATOR} submitBatch --key-file=${ORACLE_WALLET0} \
+    --args String:GWEI String:${CHAIN_SPECIFIC_TOKEN_TICKER} u64:${CURRENT_TIME} n:${FEE} u8:0 \
+    --await --sign --node ${PROXY}
 
     CURRENT_TIME=$(date +%s)
-    mxpy --verbose contract call ${AGGREGATOR} --recall-nonce --pem=${ORACLE_WALLET1} \
-    --gas-limit=15000000 --function="submitBatch" \
-    --arguments str:GWEI str:${CHAIN_SPECIFIC_TOKEN_TICKER} ${CURRENT_TIME} ${FEE} 0 \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    operator sc invoke ${AGGREGATOR} submitBatch --key-file=${ORACLE_WALLET1} \
+    --args String:GWEI String:${CHAIN_SPECIFIC_TOKEN_TICKER} u64:${CURRENT_TIME} n:${FEE} u8:0 \
+    --await --sign --node ${PROXY}
 
     CURRENT_TIME=$(date +%s)
-    mxpy --verbose contract call ${AGGREGATOR} --recall-nonce --pem=${ORACLE_WALLET2} \
-    --gas-limit=15000000 --function="submitBatch" \
-    --arguments str:GWEI str:${CHAIN_SPECIFIC_TOKEN_TICKER} ${CURRENT_TIME} ${FEE} 0 \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    operator sc invoke ${AGGREGATOR} submitBatch --key-file=${ORACLE_WALLET2} \
+    --args String:GWEI String:${CHAIN_SPECIFIC_TOKEN_TICKER} u64:${CURRENT_TIME} n:${FEE} u8:0 \
+    --await --sign --node ${PROXY}
 }
 
 setPairDecimals() {
     CHECK_VARIABLES AGGREGATOR
 
-    mxpy contract call ${AGGREGATOR} --recall-nonce "${MXPY_SIGN[@]}" \
-        --gas-limit=15000000 --function="setPairDecimals" \
-        --arguments str:GWEI str:${CHAIN_SPECIFIC_TOKEN_TICKER} 0 \
-        --send --proxy=${PROXY} --chain=${CHAIN_ID} || return  
+    operator sc invoke ${AGGREGATOR} setPairDecimals --key-file=${ALICE} \
+    --args String:GWEI String:${CHAIN_SPECIFIC_TOKEN_TICKER} u8:0 \
+    --await --sign --node ${PROXY}
 }
 
 pauseAggregator() {
     CHECK_VARIABLES AGGREGATOR
 
-    mxpy contract call ${AGGREGATOR} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=5000000 --function="pause" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID} || return
-}
-
-pauseAggregatorV2() {
-    CHECK_VARIABLES AGGREGATOR_v2
-
-    mxpy contract call ${AGGREGATOR_v2} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=5000000 --function="pause" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    operator sc invoke ${AGGREGATOR} pause --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 unpauseAggregator() {
     CHECK_VARIABLES AGGREGATOR
 
-    mxpy contract call ${AGGREGATOR} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=5000000 --function="unpause" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    operator sc invoke ${AGGREGATOR} unpause --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 aggregator-upgrade() {
     CHECK_VARIABLES AGGREGATOR AGGREGATOR_WASM
 
-    mxpy contract upgrade ${AGGREGATOR} --bytecode=${AGGREGATOR_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=100000000 --send \
-    --outfile="upgrade-aggregator.json" --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    operator sc upgrade ${AGGREGATOR} --key-file=${ALICE} \
+    --wasm ${AGGREGATOR_WASM} \
+    --await --sign --node ${PROXY}
 }

--- a/multisig/interaction/config/check-curl-result.sh
+++ b/multisig/interaction/config/check-curl-result.sh
@@ -1,0 +1,34 @@
+check_curl_error() {
+    if [ $? -ne 0 ];
+    then
+        printf "Curl error\n\n"
+        exit 1
+    fi
+    # jq for error 
+    ERROR=$(jq -r '.error' <<< "${QUERY_RESULT}")
+    # check if error is not empty
+    if [ ! -z "${ERROR}" ];    
+    then
+        printf "Error: ${ERROR}\n\n"
+        exit 1
+    fi
+}
+
+check_result() {
+    # check if SC_RESULT is empty
+    if [ -z "${SC_RESULT}" ];
+    then
+        printf "SC_RESULT is empty\n\n"
+        exit 1
+    fi
+    # jq SC_RESULT for error
+    STATUS=$(jq -r '.status' <<< "${SC_RESULT}")
+    printf "Status: ${STATUS}\n\n"
+
+    # check if status is success
+    if [ ${STATUS} != "success" ];
+    then
+        printf "Error: ${SC_RESULT}\n\n"
+        exit 1
+    fi
+}

--- a/multisig/interaction/config/configs.cfg
+++ b/multisig/interaction/config/configs.cfg
@@ -1,47 +1,33 @@
-ESDT_SYSTEM_SC_ADDRESS=erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u
-
 #============CHAIN==============
 
-PROXY=https://testnet-gateway.multiversx.com
-CHAIN_ID=T
+PROXY=http://localhost:8080
+CHAIN_ID=420420
 
 #============OWNER==============
 
-ALICE="./wallets/erd1zsha9cvx7gwraytgp740dcjzwy9v5xwnmas77d33uve6sk0rs0vqel4ln5.pem"
-ALICE_ADDRESS=erd1zsha9cvx7gwraytgp740dcjzwy9v5xwnmas77d33uve6sk0rs0vqel4ln5
+ALICE="./wallets/klv12e0kqcvqsrayj8j0c4dqjyvnv4ep253m5anx4rfj4jeq34lxsg8s84ec9j.pem"
+ALICE_ADDRESS=klv12e0kqcvqsrayj8j0c4dqjyvnv4ep253m5anx4rfj4jeq34lxsg8s84ec9j
 
-MXPY_SIGN=()
-#use this for signing transactions with a pem file
-#MXPY_SIGN+=(--pem=${ALICE})
-#use this to sign with ledger
-MXPY_SIGN+=(--ledger)
 
 #============WASM FILES==============
 
-AGGREGATOR_WASM="./multiversx-price-aggregator-sc.wasm"
-SAFE_WASM="./esdt-safe.wasm"
+AGGREGATOR_WASM="./klv-price-aggregator-sc.wasm"
+SAFE_WASM="./kda-safe.wasm"
 BRIDGED_TOKENS_WRAPPER_WASM="./bridged-tokens-wrapper.wasm"
-MULTI_TRANSFER_WASM="./multi-transfer-esdt.wasm"
+MULTI_TRANSFER_WASM="./multi-transfer-kda.wasm"
 MULTISIG_WASM="./multisig.wasm"
-PROXY_WASM="./bridge-proxy.wasm"
 FAUCET_WASM="./faucet.wasm"
 TEST_CALLER_WASM="./test-caller.wasm"
 
 #============CONTRACT ADDRESSES==============
 
-AGGREGATOR=erd1qqqqqqqqqqqqqpgqnlxmcs47kunkewcllqh0d72gv5pjhvfvs0vqa57fhf
-SAFE=erd1qqqqqqqqqqqqqpgqkhx64czgpc84eftg6q25lrfyv95ndwtcs0vqwusfuh
-BRIDGED_TOKENS_WRAPPER=erd1qqqqqqqqqqqqqpgqlgjwk8mpfycxpdf9q2sgzcndtdhdxr5ss0vqgygjmn
-MULTI_TRANSFER=erd1qqqqqqqqqqqqqpgqjsh8kss3w67xks7ths5d795q3nz8y52as0vqu0ujzg
-MULTISIG=erd1qqqqqqqqqqqqqpgqdcat402y6c62hv07gt04rynjg4668z9fs0vq3qxepp
-BRIDGE_PROXY=erd1qqqqqqqqqqqqqpgqk09rka2dslnf9ns5eze2s5xw2hfjxm0jzlsqzyjh28
-FAUCET=erd1qqqqqqqqqqqqqpgqhhlx9mpdc92l0psszy3cf9lxhg9vzhs8zlsqjeeqqn
-TEST_CALLER=erd1qqqqqqqqqqqqqpgq398fy44g59se3pkmjz8tya39pz5q4tuvpqqqgwffes
-
-#============v2 CONTRACT ADDRESSES==============
-MULTISIG_v2=erd1qqqqqqqqqqqqqpgqu5asufdaxnzxhxgjheuee2mzm28y205rzcqq25xvky
-AGGREGATOR_v2=erd1qqqqqqqqqqqqqpgqxgpczmmcjr64ladk2hz05gm6j73usrugzcqqmhhzd0
-BRIDGED_TOKENS_WRAPPER_v2=erd1qqqqqqqqqqqqqpgqgvx0y4c9ael8ha29cvn0c3r6ay5c9heezcqq2nejur
+AGGREGATOR=klv1qqqqqqqqqqqqqpgqnrjh03d24xzy6ln7rs4xfdl89e9d7vqxsg8sd07qzf
+SAFE=klv1qqqqqqqqqqqqqpgq09l6mnkz358za2kydkf7r3ejz0agu27rsg8s6esxsj
+BRIDGED_TOKENS_WRAPPER=klv1qqqqqqqqqqqqqpgq4y9nzqkmn9xw3j4lzlkq26e2rxvxshutsg8srgfdz8
+MULTI_TRANSFER=klv1qqqqqqqqqqqqqpgqnc2gh5ml6x5u8kphxslypkrzqvuxxnuusg8s6yda6c
+MULTISIG=klv1qqqqqqqqqqqqqpgq5p7g03uamk9l5qh92n2fewq4k2zz3njmsg8snr852r
+FAUCET=
+TEST_CALLER=
 
 #============TOKENS SETTINGS==============
 NR_DECIMALS_CHAIN_SPECIFIC=6
@@ -55,11 +41,11 @@ CHAIN_SPECIFIC_TOKEN_DISPLAY_NAME=EthereumWrappedUSDC
 UNIVERSAL_TOKENS_ALREADY_MINTED=0 # do not add the decimals on this value
 
 #============TOKENS TO BE WHITELISTED==============
-UNIVERSAL_TOKEN=
-CHAIN_SPECIFIC_TOKEN=MEX-a659d0
-ERC20_TOKEN=0x2E8e0BBe20Ecd819c721D164fb91F7c33BDFC756
+UNIVERSAL_TOKEN=USDC-2GSV
+CHAIN_SPECIFIC_TOKEN=ETHUSDC-3RRK
+ERC20_TOKEN=82afDD299Adf4b1e6E101BF6508b52384aa0714f
 MINTBURN_WHITELIST=true
-NATIVE_TOKEN=true
+NATIVE_TOKEN=false
 
 TOTAL_BALANCE=0
 MINT_BALANCE=0
@@ -69,10 +55,10 @@ BURN_BALANCE=0
 FEE_AMOUNT=50 # value without decimals
 MAX_AMOUNT=100000 # value without decimals
 
-RELAYER_REQUIRED_STAKE=0 #1000eGLD
+RELAYER_REQUIRED_STAKE=10 #10KLV
 SLASH_AMOUNT=0
 QUORUM=3
-ORACLE_REQUIRED_STAKE=1 #1EGLD
+ORACLE_REQUIRED_STAKE=1 #1KLV
 
 MAX_TX_PER_BATCH=70
 MAX_TX_BLOCK_DURATION_PER_BATCH=100 #10minutes
@@ -80,16 +66,16 @@ MAX_TX_BLOCK_DURATION_PER_BATCH=100 #10minutes
 ETH_MAX_AMOUNT=0
 
 #============RELAYERS ADDRESSES==============
-RELAYER_ADDR_0=erd1l9hpewk3dd6mz5j0yytjnzqtydukslmsms2d0fn0pg8pc42chqgqk8pm5u
-RELAYER_ADDR_1=erd1tfj6fpr5hd5fw8h6efycw42mk3c4wynausntvg6x98kcyn5npkkqmq7t9g
-RELAYER_ADDR_2=erd1689ky73s93aptw8ek0wrrzujtus365ygrqgj0hgj4cn09n5k3kuqyhr0j7
-RELAYER_ADDR_3=erd1uae36y2qvrslexcv3mwjqy9lwrlspvkdyjsar2xcj5ctrq7th26q8twvyc
-RELAYER_ADDR_4=erd1pkwhtl85ze02ckaf0t6qgycgx863kxyefxyqxumcth0nwtu3a9yqzg2yn2
-RELAYER_ADDR_5=erd197rmyux8ttzuwssh9thsewlzsc766tvpnussqkpew5vm9x63k0kqw56hr7
-RELAYER_ADDR_6=erd1yhqfhsf237uyz4uzzg0duy9hhg8t3j4wtt020c5cy59w2v2jvkgq6nxf0c
-RELAYER_ADDR_7=erd1pgvt06tyhlwegkdkzknyhcxfl3wz69wseqeqashm3d83mxjaewzqnug90w
-RELAYER_ADDR_8=erd1ujfl0yxff6ey008ef89au4dn486dj549kpjuuu4xxtn9q550x3gqcu6wed
-RELAYER_ADDR_9=erd1zsha9cvx7gwraytgp740dcjzwy9v5xwnmas77d33uve6sk0rs0vqel4ln5
+RELAYER_ADDR_0=klv1e3jsvrfyt7qw4xm75js76q44jyhl8hjr95fgxlu7p3chzl2xprzss4nndl
+RELAYER_ADDR_1=klv1evsuhmz5taadc443kynf4074njy60ydgtayazh6dkq8f4lztcreq3w4xhk
+RELAYER_ADDR_2=klv1hdhtwsdheh9fyfdf6q6p6ds3hq2wgaupvrk5r3d0yl06khcu8nxq2g0x4g
+RELAYER_ADDR_3=klv1pp8de896uv9j6y038xwh9tdsncvju38tuxnkx3ewxpenp3hx4nlquunlyn
+RELAYER_ADDR_4=klv1sdpxun2dxwne27szluqws4ekj38shdsps494rxc0xdamke0mp8mq28m5ah
+RELAYER_ADDR_5=klv1yfngsq0tjt3jdmtjzzcxkt58afazl2lhcfc26gtxfrvcg33jdt6qtwg8rk
+RELAYER_ADDR_6=klv1z3pmycjzh67kh7lkm889lhww5mj7p0zpgjl2dvghfdqhwghlw2fq7fl7l6
+RELAYER_ADDR_7=klv166khda6z5wfqeh4el0tzh6gc2j578xzxu8dcmgzj2aa24urd5u6sk4mpjk
+RELAYER_ADDR_8=klv166knsusx7kwalsltyk99f4gpulj5mhl0lv2pf9syg97s2ps08jpq9g9s7n
+RELAYER_ADDR_9=klv1476tk9vl2qkwtlk467qx7eqlmwemlu8chfh9a468xermd72xg64sgqc40y
 
 RELAYER_WALLET0="./walletsRelay/${RELAYER_ADDR_0}.pem"
 RELAYER_WALLET1="./walletsRelay/${RELAYER_ADDR_1}.pem"
@@ -103,9 +89,9 @@ RELAYER_WALLET8="./walletsRelay/${RELAYER_ADDR_8}.pem"
 RELAYER_WALLET9="./walletsRelay/${RELAYER_ADDR_9}.pem"
 
 #============ORACLE ADDRESSES==============
-ORACLE_ADDR_0=erd1ek7r87m623y94n8htdjhmhwud6vwhxanwl2xzdfl3kccejhefuqqhwjmv2
-ORACLE_ADDR_1=erd1vpz5mpsttd9q5puuaqr7kxfjhwsv2zqqu9jdhyrvkpyfhpnsf5qqhtkkca
-ORACLE_ADDR_2=erd10f8xflx9svsje0v2ujggp76jkzyxwpj0rxzgmvx5kle5vqk4f5qqg57m7t
+ORACLE_ADDR_0=klv1qx8lk9dt0enm98psnym23qpf8rjhzafsd25upszh66wxsg0efd6q8ds3jx
+ORACLE_ADDR_1=klv1yyh2sjey7resf8yjjuz6chgysajuhva2e27rrvsvferlez59w0psdrlp4c
+ORACLE_ADDR_2=klv1zqv4vlnh7pd2kswyg34gp0u7td5laj6nmuh24n4cr5typdwjn8as48273u
 
 ORACLE_WALLET0="./walletsOracle/${ORACLE_ADDR_0}.pem"
 ORACLE_WALLET1="./walletsOracle/${ORACLE_ADDR_1}.pem"

--- a/multisig/interaction/config/issue-tokens-snippets.sh
+++ b/multisig/interaction/config/issue-tokens-snippets.sh
@@ -1,27 +1,26 @@
-ESDT_ISSUE_COST=50000000000000000
-
 issueUniversalToken() {
-    CHECK_VARIABLES ESDT_SYSTEM_SC_ADDRESS ESDT_ISSUE_COST UNIVERSAL_TOKEN_DISPLAY_NAME \
-    UNIVERSAL_TOKEN_TICKER NR_DECIMALS_UNIVERSAL
+    CHECK_VARIABLES UNIVERSAL_TOKEN_DISPLAY_NAME UNIVERSAL_TOKEN_TICKER NR_DECIMALS_UNIVERSAL
 
-    mxpy contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --value=${ESDT_ISSUE_COST} --function="issue" \
-    --arguments str:${UNIVERSAL_TOKEN_DISPLAY_NAME} str:${UNIVERSAL_TOKEN_TICKER} \
-    0 ${NR_DECIMALS_UNIVERSAL} str:canAddSpecialRoles str:true \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    # KDA Asset Type 0: Fungible token
+    local KDA_TYPE_FUNGIBLE=0
+
+    operator kda create ${KDA_TYPE_FUNGIBLE} --canMint=true --canBurn=true --canAddRoles=true --initialSupply=0 \
+    --name=${UNIVERSAL_TOKEN_DISPLAY_NAME} --ticker=${UNIVERSAL_TOKEN_TICKER} --precision=${NR_DECIMALS_UNIVERSAL} \
+    --key-file=${ALICE} --await --sign --node ${PROXY}
 }
 
 issueChainSpecificToken() {
-    CHECK_VARIABLES ESDT_SYSTEM_SC_ADDRESS ESDT_ISSUE_COST CHAIN_SPECIFIC_TOKEN_DISPLAY_NAME \
-    CHAIN_SPECIFIC_TOKEN_TICKER NR_DECIMALS_CHAIN_SPECIFIC UNIVERSAL_TOKENS_ALREADY_MINTED
+    CHECK_VARIABLES CHAIN_SPECIFIC_TOKEN_DISPLAY_NAME CHAIN_SPECIFIC_TOKEN_TICKER \
+    NR_DECIMALS_CHAIN_SPECIFIC UNIVERSAL_TOKENS_ALREADY_MINTED
     
     VALUE_TO_MINT=$(echo "scale=0; $UNIVERSAL_TOKENS_ALREADY_MINTED*10^$NR_DECIMALS_CHAIN_SPECIFIC/1" | bc)
 
-    mxpy contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --value=${ESDT_ISSUE_COST} --function="issue" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN_DISPLAY_NAME} str:${CHAIN_SPECIFIC_TOKEN_TICKER} \
-    ${VALUE_TO_MINT} ${NR_DECIMALS_CHAIN_SPECIFIC} str:canAddSpecialRoles str:true \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    # KDA Asset Type 0: Fungible token
+    local KDA_TYPE_FUNGIBLE=0
+
+    operator kda create ${KDA_TYPE_FUNGIBLE} --canMint=true --canBurn=true --canAddRoles=true --initialSupply=${VALUE_TO_MINT} \
+    --name=${CHAIN_SPECIFIC_TOKEN_DISPLAY_NAME} --ticker=${CHAIN_SPECIFIC_TOKEN_TICKER} --precision=${NR_DECIMALS_CHAIN_SPECIFIC} \
+    --key-file=${ALICE} --await --sign --node ${PROXY}
 }
 
 transferToSC() {
@@ -29,32 +28,38 @@ transferToSC() {
 
     VALUE_TO_MINT=$(echo "scale=0; $UNIVERSAL_TOKENS_ALREADY_MINTED*10^$NR_DECIMALS_CHAIN_SPECIFIC/1" | bc)
 
-    mxpy contract call ${BRIDGED_TOKENS_WRAPPER} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=5000000 --function="ESDTTransfer" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN} ${VALUE_TO_MINT} str:depositLiquidity \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator transfer --sender=${ALICE_ADDRESS} --receiver=${BRIDGED_TOKENS_WRAPPER} --assets=${CHAIN_SPECIFIC_TOKEN}:${VALUE_TO_MINT} \
+    --payload=depositLiquidity --key-file=${ALICE} --await --sign --node ${PROXY}
 }
 
 setMintRole() {
-    mxpy contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="setSpecialRole" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN} ${ALICE_ADDRESS} str:ESDTRoleLocalMint \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    CHECK_VARIABLES CHAIN_SPECIFIC_TOKEN ALICE_ADDRESS
+    
+    # Trigger 6: AddRole - Add a permission role to the asset
+    local TRIGGER_ADD_ROLE=6
+
+    operator kda trigger ${TRIGGER_ADD_ROLE} --kdaID=${CHAIN_SPECIFIC_TOKEN} --addRolesMint=${ALICE_ADDRESS} --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 unSetMintRole() {
-    mxpy contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="unSetSpecialRole" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN} ${ALICE_ADDRESS} str:ESDTRoleLocalMint \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    CHECK_VARIABLES CHAIN_SPECIFIC_TOKEN
+    
+    # Trigger 7: RemoveRole - Remove a permission role of the asset
+    local TRIGGER_REMOVE_ROLE=7
+
+    operator kda trigger ${TRIGGER_REMOVE_ROLE} --kdaID=${CHAIN_SPECIFIC_TOKEN} --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 mint() {
-    CHECK_VARIABLES NR_DECIMALS_CHAIN_SPECIFIC ALICE_ADDRESS CHAIN_SPECIFIC_TOKEN
+    CHECK_VARIABLES NR_DECIMALS_CHAIN_SPECIFIC CHAIN_SPECIFIC_TOKEN ALICE_ADDRESS
     read -p "Amount to mint(without decimals): " AMOUNT_TO_MINT
     VALUE_TO_MINT=$(echo "scale=0; $AMOUNT_TO_MINT*10^$NR_DECIMALS_CHAIN_SPECIFIC/1" | bc)
-    mxpy contract call ${ALICE_ADDRESS} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=300000 --function="ESDTLocalMint" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN} ${VALUE_TO_MINT} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    
+    # Trigger 0: Mint - Directly mint assets in the receiver
+    local TRIGGER_MINT=0
+    
+    operator kda trigger ${TRIGGER_MINT} --kdaID=${CHAIN_SPECIFIC_TOKEN} --receiver=${ALICE_ADDRESS} --amount=${VALUE_TO_MINT} --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }

--- a/multisig/interaction/config/issue-tokens-snippets.sh
+++ b/multisig/interaction/config/issue-tokens-snippets.sh
@@ -28,8 +28,8 @@ transferToSC() {
 
     VALUE_TO_MINT=$(echo "scale=0; $UNIVERSAL_TOKENS_ALREADY_MINTED*10^$NR_DECIMALS_CHAIN_SPECIFIC/1" | bc)
 
-    operator transfer --sender=${ALICE_ADDRESS} --receiver=${BRIDGED_TOKENS_WRAPPER} --assets=${CHAIN_SPECIFIC_TOKEN}:${VALUE_TO_MINT} \
-    --payload=depositLiquidity --key-file=${ALICE} --await --sign --node ${PROXY}
+    operator sc invoke ${BRIDGED_TOKENS_WRAPPER} depositLiquidity --values ${CHAIN_SPECIFIC_TOKEN}=${VALUE_TO_MINT} \
+     --key-file=${ALICE} --await --sign --node ${PROXY}
 }
 
 setMintRole() {

--- a/multisig/interaction/config/mainnet-release-v3.sh
+++ b/multisig/interaction/config/mainnet-release-v3.sh
@@ -1,25 +1,24 @@
 deployMultisigMainnetV3() {
     CHECK_VARIABLES RELAYER_ADDR_0 RELAYER_ADDR_1 RELAYER_ADDR_2 RELAYER_ADDR_3 \
     RELAYER_ADDR_4 RELAYER_ADDR_5 RELAYER_ADDR_6 RELAYER_ADDR_7 RELAYER_ADDR_8 \
-    RELAYER_ADDR_9 SAFE MULTI_TRANSFER BRIDGE_PROXY RELAYER_REQUIRED_STAKE SLASH_AMOUNT QUORUM MULTISIG_WASM
+    RELAYER_ADDR_9 SAFE MULTI_TRANSFER RELAYER_REQUIRED_STAKE SLASH_AMOUNT QUORUM MULTISIG_WASM
 
-    MIN_STAKE=$(echo "$RELAYER_REQUIRED_STAKE*10^18" | bc)
-    mxpy contract deploy --bytecode=${MULTISIG_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=200000000 \
-    --arguments ${SAFE} ${MULTI_TRANSFER} ${BRIDGE_PROXY} \
-    ${MIN_STAKE} ${SLASH_AMOUNT} ${QUORUM} \
-    ${RELAYER_ADDR_0} ${RELAYER_ADDR_1} ${RELAYER_ADDR_2} ${RELAYER_ADDR_3} \
-    ${RELAYER_ADDR_4} ${RELAYER_ADDR_5} ${RELAYER_ADDR_6} ${RELAYER_ADDR_7} \
-    ${RELAYER_ADDR_8} ${RELAYER_ADDR_9} \
-    --send --outfile="deploy-testnet.interaction.json" --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    MIN_STAKE=$(echo "$RELAYER_REQUIRED_STAKE*10^6" | bc)
+    
+    SC_RESULT=$(eval operator sc create --key-file=${ALICE} --wasm ${MULTISIG_WASM} \
+    --args A:${SAFE} --args A:${MULTI_TRANSFER} \
+    --args n:${MIN_STAKE} --args n:${SLASH_AMOUNT} --args n:${QUORUM} \
+    --args A:${RELAYER_ADDR_0} --args A:${RELAYER_ADDR_1} --args A:${RELAYER_ADDR_2} --args A:${RELAYER_ADDR_3} \
+    --args A:${RELAYER_ADDR_4} --args A:${RELAYER_ADDR_5} --args A:${RELAYER_ADDR_6} --args A:${RELAYER_ADDR_7} \
+    --args A:${RELAYER_ADDR_8} --args A:${RELAYER_ADDR_9} \
+    --await --result-only --sign --node ${PROXY})
 
-    TRANSACTION=$(mxpy data parse --file="./deploy-testnet.interaction.json" --expression="data['emitted_tx']['hash']")
-    ADDRESS=$(mxpy data parse --file="./deploy-testnet.interaction.json" --expression="data['contractAddress']")
+    check_result ${SC_RESULT}
 
-    mxpy data store --key=address-testnet-multisig --value=${ADDRESS}
-    mxpy data store --key=deployTransaction-testnet --value=${TRANSACTION}
+    CONTRACT_ADDRESS=$(jq '.logs.events[] | select(.identifier=="SCDeploy") | .address' <<< "${SC_RESULT}")
+    CONTRACT_ADDRESS=$(echo ${CONTRACT_ADDRESS} | tr -d '"')
 
     echo ""
-    echo "Multisig contract address: ${ADDRESS}"
-    update-config MULTISIG ${ADDRESS}
+    echo "Multisig contract address: ${CONTRACT_ADDRESS}"
+    update-config MULTISIG ${CONTRACT_ADDRESS}
 }

--- a/multisig/interaction/config/menu_functions.cfg
+++ b/multisig/interaction/config/menu_functions.cfg
@@ -10,6 +10,7 @@ source $SCRIPTPATH/config/relayers-snippets.sh
 source $SCRIPTPATH/config/wrapped-snippets.sh
 source $SCRIPTPATH/config/safe-snippets.sh
 source $SCRIPTPATH/config/testing.sh
+source $SCRIPTPATH/config/check-curl-result.sh
 
 CHECK_VARIABLES ALICE PROXY CHAIN_ID
 
@@ -36,12 +37,9 @@ function deploy-bridge-contracts {
   manual-update-config-file
   confirmation-with-skip deploySafe
   manual-update-config-file
-  confirmation-with-skip deployBridgeProxy
-  manual-update-config-file
   confirmation-with-skip deployMultisig
   manual-update-config-file
 
-  confirmation-with-skip setBridgeProxyContractAddressOnMultiTransfer
   confirmation-with-skip setBridgedTokensWrapperOnMultiTransfer
 
   confirmation-with-skip setBridgedTokensWrapperOnSCProxy
@@ -49,11 +47,9 @@ function deploy-bridge-contracts {
   confirmation-with-skip setEsdtSafeOnSCProxy
 
   confirmation-with-skip setBridgedTokensWrapperOnEsdtSafe
-  confirmation-with-skip setSCProxyOnEsdtSafe
 
   confirmation-with-skip changeChildContractsOwnershipSafe
   confirmation-with-skip changeChildContractsOwnershipMultiTransfer
-  confirmation-with-skip changeChildContractsOwnershipProxy
 
   confirmation-with-skip setEsdtSafeOnMultiTransferThroughMultisig
 

--- a/multisig/interaction/config/menu_functions.cfg
+++ b/multisig/interaction/config/menu_functions.cfg
@@ -39,6 +39,8 @@ function deploy-bridge-contracts {
   confirmation-with-skip deployMultisig
   manual-update-config-file
 
+  confirmation-with-skip addAdminToKdaSafe
+  confirmation-with-skip addAdminToMultiTransfer
   confirmation-with-skip setBridgedTokensWrapperOnMultiTransfer
 
   confirmation-with-skip setBridgedTokensWrapperOnKdaSafe

--- a/multisig/interaction/config/menu_functions.cfg
+++ b/multisig/interaction/config/menu_functions.cfg
@@ -44,14 +44,14 @@ function deploy-bridge-contracts {
 
   confirmation-with-skip setBridgedTokensWrapperOnSCProxy
   confirmation-with-skip setMultiTransferOnSCProxy
-  confirmation-with-skip setEsdtSafeOnSCProxy
+  confirmation-with-skip setKdaSafeOnSCProxy
 
-  confirmation-with-skip setBridgedTokensWrapperOnEsdtSafe
+  confirmation-with-skip setBridgedTokensWrapperOnKdaSafe
 
   confirmation-with-skip changeChildContractsOwnershipSafe
   confirmation-with-skip changeChildContractsOwnershipMultiTransfer
 
-  confirmation-with-skip setEsdtSafeOnMultiTransferThroughMultisig
+  confirmation-with-skip setKdaSafeOnMultiTransferThroughMultisig
 
   confirmation-with-skip stakeRelayers
 }
@@ -65,8 +65,7 @@ function remove-whitelist-token {
 
   confirmation-with-skip removeWrappedToken
   confirmation-with-skip wrapper-blacklistToken
-  confirmation-with-skip unsetLocalRolesEsdtSafe
-  confirmation-with-skip unsetLocalRolesMultiTransferEsdt
+  confirmation-with-skip unsetLocalRolesKdaSafe
   confirmation-with-skip clearMapping
   confirmation-with-skip removeTokenFromWhitelist
 }
@@ -90,7 +89,7 @@ function whitelist-token {
   confirmation-with-skip transferToSC
   confirmation-with-skip addWrappedToken
   confirmation-with-skip wrapper-whitelistToken
-  confirmation-with-skip setLocalRolesEsdtSafe
+  confirmation-with-skip setLocalRolesKdaSafe
   confirmation-with-skip addMapping
   confirmation-with-skip addTokenToWhitelist
   echo -e 
@@ -101,12 +100,12 @@ function whitelist-token {
   confirmation-with-skip setPairDecimals
   confirmation-with-skip submitAggregatorBatch
 
-  confirmation-with-skip esdtSafeSetMaxBridgedAmountForToken
-  confirmation-with-skip multiTransferEsdtSetMaxBridgedAmountForToken
+  confirmation-with-skip kdaSafeSetMaxBridgedAmountForToken
+  confirmation-with-skip multiTransferKdaSetMaxBridgedAmountForToken
 }
 
 function whitelist-native-token {
-  confirmation-with-skip setLocalRolesEsdtSafe
+  confirmation-with-skip setLocalRolesKdaSafe
   confirmation-with-skip addMapping
   confirmation-with-skip addTokenToWhitelist
   echo -e 
@@ -117,8 +116,8 @@ function whitelist-native-token {
   confirmation-with-skip setPairDecimals
   confirmation-with-skip submitAggregatorBatch
 
-  confirmation-with-skip esdtSafeSetMaxBridgedAmountForToken
-  confirmation-with-skip multiTransferEsdtSetMaxBridgedAmountForToken
+  confirmation-with-skip kdaSafeSetMaxBridgedAmountForToken
+  confirmation-with-skip multiTransferKdaSetMaxBridgedAmountForToken
 }
 
 function change-quorum {
@@ -130,18 +129,18 @@ function change-quorum {
 function set-safe-max-tx {
   read -p "New batch size: " BATCH_SIZE
   update-config MAX_TX_PER_BATCH ${BATCH_SIZE}
-  esdtSafeSetMaxTxBatchSize
+  kdaSafeSetMaxTxBatchSize
 }
 
 function set-safe-batch-block-duration {
   read -p "New batch block duration: " BLOCK_DURATION
   update-config MAX_TX_BLOCK_DURATION_PER_BATCH ${BLOCK_DURATION}
-  esdtSafeSetMaxTxBatchBlockDuration
+  kdaSafeSetMaxTxBatchBlockDuration
 }
 
 function pause-contracts {
   confirmation-with-skip pause
-  confirmation-with-skip pauseEsdtSafe
+  confirmation-with-skip pauseKdaSafe
   confirmation-with-skip pauseAggregator
   confirmation-with-skip wrapper-pause
   confirmation-with-skip pauseProxy
@@ -149,7 +148,7 @@ function pause-contracts {
 
 function unpause-contracts {
   confirmation-with-skip unpause
-  confirmation-with-skip unpauseEsdtSafe
+  confirmation-with-skip unpauseKdaSafe
   confirmation-with-skip unpauseAggregator
   confirmation-with-skip wrapper-unpause
   confirmation-with-skip unpauseProxy
@@ -212,7 +211,7 @@ function deploy-test-caller {
 
 function pause-v2-contracts {
       confirmation-with-skip pauseV2
-      confirmation-with-skip pauseEsdtSafeV2
+      confirmation-with-skip pauseKdaSafeV2
       confirmation-with-skip pauseAggregatorV2
       confirmation-with-skip wrapper-pauseV2
 }

--- a/multisig/interaction/config/menu_functions.cfg
+++ b/multisig/interaction/config/menu_functions.cfg
@@ -5,7 +5,6 @@ source $SCRIPTPATH/config/aggregator-snippets.sh
 source $SCRIPTPATH/config/issue-tokens-snippets.sh
 source $SCRIPTPATH/config/multisig-snippets.sh
 source $SCRIPTPATH/config/multitransfer-snippets.sh
-source $SCRIPTPATH/config/proxy-snippets.sh
 source $SCRIPTPATH/config/relayers-snippets.sh
 source $SCRIPTPATH/config/wrapped-snippets.sh
 source $SCRIPTPATH/config/safe-snippets.sh
@@ -41,10 +40,6 @@ function deploy-bridge-contracts {
   manual-update-config-file
 
   confirmation-with-skip setBridgedTokensWrapperOnMultiTransfer
-
-  confirmation-with-skip setBridgedTokensWrapperOnSCProxy
-  confirmation-with-skip setMultiTransferOnSCProxy
-  confirmation-with-skip setKdaSafeOnSCProxy
 
   confirmation-with-skip setBridgedTokensWrapperOnKdaSafe
 
@@ -143,7 +138,6 @@ function pause-contracts {
   confirmation-with-skip pauseKdaSafe
   confirmation-with-skip pauseAggregator
   confirmation-with-skip wrapper-pause
-  confirmation-with-skip pauseProxy
 }
 
 function unpause-contracts {
@@ -151,7 +145,6 @@ function unpause-contracts {
   confirmation-with-skip unpauseKdaSafe
   confirmation-with-skip unpauseAggregator
   confirmation-with-skip wrapper-unpause
-  confirmation-with-skip unpauseProxy
 }
 
 function set-fee {
@@ -182,11 +175,6 @@ function upgrade-safe {
 function upgrade-multi-transfer {
     confirmation-with-skip deployMultiTransferForUpgrade
     confirmation-with-skip upgradeMultiTransferContract
-}
-
-function upgrade-proxy {
-    confirmation-with-skip deployBridgeProxyForUpgrade
-    confirmation-with-skip upgradeBridgeProxyContract
 }
 
 function upgrade-multisig {

--- a/multisig/interaction/config/multisig-snippets.sh
+++ b/multisig/interaction/config/multisig-snippets.sh
@@ -26,7 +26,7 @@ deployMultisig() {
 changeChildContractsOwnershipSafe() {
     CHECK_VARIABLES SAFE MULTISIG
 
-    operator sc invoke ${SAFE} changeOwnerAddress --key-file=${ALICE} \
+    operator sc invoke ${SAFE} addAdmin --key-file=${ALICE} \
     --args A:${MULTISIG} \
     --await --sign --node ${PROXY}
 }
@@ -34,7 +34,7 @@ changeChildContractsOwnershipSafe() {
 changeChildContractsOwnershipMultiTransfer() {
     CHECK_VARIABLES MULTI_TRANSFER MULTISIG
     
-    operator sc invoke ${MULTI_TRANSFER} changeOwnerAddress --key-file=${ALICE} \
+    operator sc invoke ${MULTI_TRANSFER} addAdmin --key-file=${ALICE} \
     --args A:${MULTISIG} \
     --await --sign --node ${PROXY}
 }

--- a/multisig/interaction/config/multisig-snippets.sh
+++ b/multisig/interaction/config/multisig-snippets.sh
@@ -3,12 +3,14 @@ deployMultisig() {
     RELAYER_ADDR_4 RELAYER_ADDR_5 RELAYER_ADDR_6 RELAYER_ADDR_7 RELAYER_ADDR_8 \
     RELAYER_ADDR_9 SAFE MULTI_TRANSFER RELAYER_REQUIRED_STAKE SLASH_AMOUNT QUORUM MULTISIG_WASM
 
-    MIN_STAKE=$(echo "$RELAYER_REQUIRED_STAKE*10^18" | bc)
+    MIN_STAKE=$(echo "$RELAYER_REQUIRED_STAKE*10^6" | bc)
     
     SC_RESULT=$(eval operator sc create --key-file=${ALICE} --wasm ${MULTISIG_WASM} \
     --args A:${SAFE} --args A:${MULTI_TRANSFER} \
     --args n:${MIN_STAKE} --args n:${SLASH_AMOUNT} --args n:${QUORUM} \
     --args A:${RELAYER_ADDR_0} --args A:${RELAYER_ADDR_1} --args A:${RELAYER_ADDR_2} --args A:${RELAYER_ADDR_3} \
+    --args A:${RELAYER_ADDR_4} --args A:${RELAYER_ADDR_5} --args A:${RELAYER_ADDR_6} --args A:${RELAYER_ADDR_7} \
+    --args A:${RELAYER_ADDR_8} --args A:${RELAYER_ADDR_9} \
     --await --result-only --sign --node ${PROXY})
 
     check_result ${SC_RESULT}
@@ -31,7 +33,7 @@ changeChildContractsOwnershipSafe() {
 
 changeChildContractsOwnershipMultiTransfer() {
     CHECK_VARIABLES MULTI_TRANSFER MULTISIG
-
+    
     operator sc invoke ${MULTI_TRANSFER} changeOwnerAddress --key-file=${ALICE} \
     --args A:${MULTISIG} \
     --await --sign --node ${PROXY}
@@ -41,7 +43,7 @@ clearMapping() {
     CHECK_VARIABLES ERC20_TOKEN CHAIN_SPECIFIC_TOKEN MULTISIG
 
     operator sc invoke ${MULTISIG} clearMapping --key-file=${ALICE} \
-    --args A:${ERC20_TOKEN} --args String:${CHAIN_SPECIFIC_TOKEN} \
+    --args hex:${ERC20_TOKEN} --args String:${CHAIN_SPECIFIC_TOKEN} \
     --await --sign --node ${PROXY}
 }
 
@@ -49,7 +51,7 @@ addMapping() {
     CHECK_VARIABLES ERC20_TOKEN CHAIN_SPECIFIC_TOKEN MULTISIG
 
     operator sc invoke ${MULTISIG} addMapping --key-file=${ALICE} \
-    --args A:${ERC20_TOKEN} --args String:${CHAIN_SPECIFIC_TOKEN} \
+    --args hex:${ERC20_TOKEN} --args String:${CHAIN_SPECIFIC_TOKEN} \
     --await --sign --node ${PROXY}
 }
 
@@ -61,7 +63,7 @@ addTokenToWhitelist() {
     BURN=$(echo "$BURN_BALANCE*10^$NR_DECIMALS_CHAIN_SPECIFIC" | bc)
 
     operator sc invoke ${MULTISIG} kdaSafeAddTokenToWhitelist --key-file=${ALICE} \
-    --args String:${CHAIN_SPECIFIC_TOKEN} --args String:${CHAIN_SPECIFIC_TOKEN_TICKER} --args A:${MINTBURN_WHITELIST} --args n:${NATIVE_TOKEN} \
+    --args String:${CHAIN_SPECIFIC_TOKEN} --args String:${CHAIN_SPECIFIC_TOKEN_TICKER} --args bool:${MINTBURN_WHITELIST} --args bool:${NATIVE_TOKEN} \
     --args n:${BALANCE} --args n:${MINT} --args n:${BURN} \
     --await --sign --node ${PROXY}
 }
@@ -248,7 +250,7 @@ upgradeMultisig() {
     SC_RESULT=$(eval operator sc upgrade ${MULTISIG} --key-file=${ALICE} \
     --wasm ${MULTISIG_WASM} \
     --args A:${SAFE} A:${MULTI_TRANSFER} \
-    --await --result-only --sign --node ${PROXY} \
+    --await --result-only --sign --node ${PROXY})
 
     check_result ${SC_RESULT}
 

--- a/multisig/interaction/config/multisig-snippets.sh
+++ b/multisig/interaction/config/multisig-snippets.sh
@@ -1,70 +1,56 @@
 deployMultisig() {
     CHECK_VARIABLES RELAYER_ADDR_0 RELAYER_ADDR_1 RELAYER_ADDR_2 RELAYER_ADDR_3 \
     RELAYER_ADDR_4 RELAYER_ADDR_5 RELAYER_ADDR_6 RELAYER_ADDR_7 RELAYER_ADDR_8 \
-    RELAYER_ADDR_9 SAFE MULTI_TRANSFER BRIDGE_PROXY RELAYER_REQUIRED_STAKE SLASH_AMOUNT QUORUM MULTISIG_WASM
+    RELAYER_ADDR_9 SAFE MULTI_TRANSFER RELAYER_REQUIRED_STAKE SLASH_AMOUNT QUORUM MULTISIG_WASM
 
     MIN_STAKE=$(echo "$RELAYER_REQUIRED_STAKE*10^18" | bc)
-    mxpy contract deploy --bytecode=${MULTISIG_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=200000000 \
-    --arguments ${SAFE} ${MULTI_TRANSFER} ${BRIDGE_PROXY} \
-    ${MIN_STAKE} ${SLASH_AMOUNT} ${QUORUM} \
-    ${RELAYER_ADDR_0} ${RELAYER_ADDR_1} ${RELAYER_ADDR_2} ${RELAYER_ADDR_3} \
-    --send --outfile="deploy-testnet.interaction.json" --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    
+    SC_RESULT=$(eval operator sc create --key-file=${ALICE} --wasm ${MULTISIG_WASM} \
+    --args A:${SAFE} A:${MULTI_TRANSFER} \
+    n:${MIN_STAKE} n:${SLASH_AMOUNT} n:${QUORUM} \
+    A:${RELAYER_ADDR_0} A:${RELAYER_ADDR_1} A:${RELAYER_ADDR_2} A:${RELAYER_ADDR_3} \
+    --await --result-only --sign --node ${PROXY})
 
-    TRANSACTION=$(mxpy data parse --file="./deploy-testnet.interaction.json" --expression="data['emitted_tx']['hash']")
-    ADDRESS=$(mxpy data parse --file="./deploy-testnet.interaction.json" --expression="data['contractAddress']")
+    check_result ${SC_RESULT}
 
-    mxpy data store --key=address-testnet-multisig --value=${ADDRESS}
-    mxpy data store --key=deployTransaction-testnet --value=${TRANSACTION}
+    CONTRACT_ADDRESS=$(jq '.logs.events[] | select(.identifier=="SCDeploy") | .address' <<< "${SC_RESULT}")
+    CONTRACT_ADDRESS=$(echo ${CONTRACT_ADDRESS} | tr -d '"')
 
     echo ""
-    echo "Multisig contract address: ${ADDRESS}"
-    update-config MULTISIG ${ADDRESS}
+    echo "Multisig contract address: ${CONTRACT_ADDRESS}"
+    update-config MULTISIG ${CONTRACT_ADDRESS}
 }
 
 changeChildContractsOwnershipSafe() {
     CHECK_VARIABLES SAFE MULTISIG
 
-    mxpy contract call ${SAFE} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=10000000 --function="ChangeOwnerAddress" \
-    --arguments ${MULTISIG} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
-}
-
-changeChildContractsOwnershipProxy() {
-    CHECK_VARIABLES BRIDGE_PROXY MULTISIG
-
-    mxpy contract call ${BRIDGE_PROXY} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=10000000 --function="ChangeOwnerAddress" \
-    --arguments ${MULTISIG} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${SAFE} changeOwnerAddress --key-file=${ALICE} \
+    --args A:${MULTISIG} \
+    --await --sign --node ${PROXY}
 }
 
 changeChildContractsOwnershipMultiTransfer() {
     CHECK_VARIABLES MULTI_TRANSFER MULTISIG
 
-    mxpy contract call ${MULTI_TRANSFER} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=10000000 --function="ChangeOwnerAddress" \
-    --arguments ${MULTISIG} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTI_TRANSFER} changeOwnerAddress --key-file=${ALICE} \
+    --args A:${MULTISIG} \
+    --await --sign --node ${PROXY}
 }
 
 clearMapping() {
     CHECK_VARIABLES ERC20_TOKEN CHAIN_SPECIFIC_TOKEN MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="clearMapping" \
-    --arguments ${ERC20_TOKEN} str:${CHAIN_SPECIFIC_TOKEN} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} clearMapping --key-file=${ALICE} \
+    --args A:${ERC20_TOKEN} String:${CHAIN_SPECIFIC_TOKEN} \
+    --await --sign --node ${PROXY}
 }
 
 addMapping() {
     CHECK_VARIABLES ERC20_TOKEN CHAIN_SPECIFIC_TOKEN MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="addMapping" \
-    --arguments ${ERC20_TOKEN} str:${CHAIN_SPECIFIC_TOKEN} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} addMapping --key-file=${ALICE} \
+    --args A:${ERC20_TOKEN} String:${CHAIN_SPECIFIC_TOKEN} \
+    --await --sign --node ${PROXY}
 }
 
 addTokenToWhitelist() {
@@ -74,165 +60,140 @@ addTokenToWhitelist() {
     MINT=$(echo "$MINT_BALANCE*10^$NR_DECIMALS_CHAIN_SPECIFIC" | bc)
     BURN=$(echo "$BURN_BALANCE*10^$NR_DECIMALS_CHAIN_SPECIFIC" | bc)
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="esdtSafeAddTokenToWhitelist" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN} str:${CHAIN_SPECIFIC_TOKEN_TICKER} ${MINTBURN_WHITELIST} ${NATIVE_TOKEN} \
-    ${BALANCE} ${MINT} ${BURN} --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} kdaSafeAddTokenToWhitelist --key-file=${ALICE} \
+    --args String:${CHAIN_SPECIFIC_TOKEN} String:${CHAIN_SPECIFIC_TOKEN_TICKER} A:${MINTBURN_WHITELIST} n:${NATIVE_TOKEN} \
+    n:${BALANCE} n:${MINT} n:${BURN} \
+    --await --sign --node ${PROXY}
 }
 
 removeTokenFromWhitelist() {
     CHECK_VARIABLES CHAIN_SPECIFIC_TOKEN CHAIN_SPECIFIC_TOKEN_TICKER MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="esdtSafeRemoveTokenFromWhitelist" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} kdaSafeRemoveTokenFromWhitelist --key-file=${ALICE} \
+    --args String:${CHAIN_SPECIFIC_TOKEN} \
+    --await --sign --node ${PROXY}
 }
 
-esdtSafeSetMaxTxBatchSize() {
+kdaSafeSetMaxTxBatchSize() {
     CHECK_VARIABLES MAX_TX_PER_BATCH MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=30000000 --function="esdtSafeSetMaxTxBatchSize" \
-    --arguments ${MAX_TX_PER_BATCH} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} kdaSafeSetMaxTxBatchSize --key-file=${ALICE} \
+    --args n:${MAX_TX_PER_BATCH} \
+    --await --sign --node ${PROXY}
 }
 
-esdtSafeSetMaxTxBatchBlockDuration() {
+kdaSafeSetMaxTxBatchBlockDuration() {
     CHECK_VARIABLES MAX_TX_BLOCK_DURATION_PER_BATCH MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=30000000 --function="esdtSafeSetMaxTxBatchBlockDuration" \
-    --arguments ${MAX_TX_BLOCK_DURATION_PER_BATCH} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
-}
-
-clearMapping() {
-    CHECK_VARIABLES ERC20_TOKEN CHAIN_SPECIFIC_TOKEN MULTISIG
-
-     mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="clearMapping" \
-    --arguments ${ERC20_TOKEN} str:${CHAIN_SPECIFIC_TOKEN} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} kdaSafeSetMaxTxBatchBlockDuration --key-file=${ALICE} \
+    --args n:${MAX_TX_BLOCK_DURATION_PER_BATCH} \
+    --await --sign --node ${PROXY}
 }
 
 changeQuorum() {
     CHECK_VARIABLES QUORUM MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="changeQuorum" \
-    --arguments ${QUORUM} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} changeQuorum --key-file=${ALICE} \
+    --args n:${QUORUM} \
+    --await --sign --node ${PROXY}
 }
 
 pause() {
     CHECK_VARIABLES MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="pause" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} pause --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 pauseV2() {
     CHECK_VARIABLES MULTISIG_v2
 
-    mxpy contract call ${MULTISIG_v2} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="pause" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG_v2} pause --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
-pauseEsdtSafe() {
+pauseKdaSafe() {
     CHECK_VARIABLES MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="pauseEsdtSafe" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} pauseKdaSafe --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
-pauseEsdtSafeV2() {
+pauseKdaSafeV2() {
     CHECK_VARIABLES MULTISIG_v2
 
-    mxpy contract call ${MULTISIG_v2} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="pauseEsdtSafe" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG_v2} pauseKdaSafe --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 pauseProxy() {
     CHECK_VARIABLES MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="pauseProxy" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} pauseProxy --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 unpause() {
     CHECK_VARIABLES MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="unpause" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} unpause --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
-unpauseEsdtSafe() {
+unpauseKdaSafe() {
     CHECK_VARIABLES MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="unpauseEsdtSafe" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} unpauseKdaSafe --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 unpauseProxy() {
     CHECK_VARIABLES MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="unpauseProxy" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} unpauseProxy --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
-esdtSafeSetMaxBridgedAmountForToken() {
+kdaSafeSetMaxBridgedAmountForToken() {
     CHECK_VARIABLES MAX_AMOUNT NR_DECIMALS_CHAIN_SPECIFIC CHAIN_SPECIFIC_TOKEN MULTISIG
 
     MAX=$(echo "scale=0; $MAX_AMOUNT*10^$NR_DECIMALS_CHAIN_SPECIFIC/1" | bc)
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="esdtSafeSetMaxBridgedAmountForToken" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN} ${MAX} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    
+    operator sc invoke ${MULTISIG} kdaSafeSetMaxBridgedAmountForToken --key-file=${ALICE} \
+    --args String:${CHAIN_SPECIFIC_TOKEN} n:${MAX} \
+    --await --sign --node ${PROXY}
 }
 
-multiTransferEsdtSetMaxBridgedAmountForToken() {
+multiTransferKdaSetMaxBridgedAmountForToken() {
     CHECK_VARIABLES MAX_AMOUNT NR_DECIMALS_CHAIN_SPECIFIC CHAIN_SPECIFIC_TOKEN MULTISIG
 
     MAX=$(echo "scale=0; $MAX_AMOUNT*10^$NR_DECIMALS_CHAIN_SPECIFIC/1" | bc)
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="multiTransferEsdtSetMaxBridgedAmountForToken" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN} ${MAX} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    
+    operator sc invoke ${MULTISIG} multiTransferKdaSetMaxBridgedAmountForToken --key-file=${ALICE} \
+    --args String:${CHAIN_SPECIFIC_TOKEN} n:${MAX} \
+    --await --sign --node ${PROXY}
 }
 
-multiTransferEsdtSetMaxBridgedAmountForTokenWithRAWValue() {
+multiTransferKdaSetMaxBridgedAmountForTokenWithRAWValue() {
     CHECK_VARIABLES ETH_MAX_AMOUNT CHAIN_SPECIFIC_TOKEN MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=40000000 --function="multiTransferEsdtSetMaxBridgedAmountForToken" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN} ${ETH_MAX_AMOUNT} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} multiTransferKdaSetMaxBridgedAmountForToken --key-file=${ALICE} \
+    --args String:${CHAIN_SPECIFIC_TOKEN} n:${ETH_MAX_AMOUNT} \
+    --await --sign --node ${PROXY}
 }
 
-
-setMultiTransferOnEsdtSafeThroughMultisig() {
+setMultiTransferOnKdaSafeThroughMultisig() {
     CHECK_VARIABLES MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="setMultiTransferOnEsdtSafe" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} setMultiTransferOnKdaSafe --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
-setEsdtSafeOnMultiTransferThroughMultisig() {
+setKdaSafeOnMultiTransferThroughMultisig() {
     CHECK_VARIABLES MULTISIG
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="setEsdtSafeOnMultiTransfer" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} setKdaSafeOnMultiTransfer --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 initSupplyMintBurn() {
@@ -251,10 +212,9 @@ initSupplyMintBurn() {
   MINT=$(echo ${MINT%.*}) # trim decimals, if existing
   BURN=$(echo ${BURN%.*}) # trim decimals, if existing
 
-  mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-  --gas-limit=60000000 --function="initSupplyMintBurnEsdtSafe" \
-  --arguments str:${CHAIN_SPECIFIC_TOKEN} ${MINT} ${BURN} \
-  --send --proxy=${PROXY} --chain=${CHAIN_ID}
+  operator sc invoke ${MULTISIG} initSupplyMintBurnKdaSafe --key-file=${ALICE} \
+  --args String:${CHAIN_SPECIFIC_TOKEN} n:${MINT} n:${BURN} \
+  --await --sign --node ${PROXY}
 }
 
 syncValueWithEthereumDenom() {
@@ -263,8 +223,13 @@ syncValueWithEthereumDenom() {
   read -p "Chain specific token (human readable): " TOKEN
   read -p "Denominated value on Ethereum (should contain all digits): " ETH_VALUE
 
-  EXISTING_BURN=$(mxpy contract query ${SAFE} --proxy=${PROXY} --function getBurnBalances --arguments str:$TOKEN | jq '.[0].number')
-  EXISTING_MINT=$(mxpy contract query ${SAFE} --proxy=${PROXY} --function getMintBalances --arguments str:$TOKEN | jq '.[0].number')
+  # Using operator to query the contract
+  SAFE_QUERY_BURN=$(operator sc query ${SAFE} getBurnBalances --args String:$TOKEN --node=${PROXY})
+  EXISTING_BURN=$(echo $SAFE_QUERY_BURN | jq '.[0].number')
+  
+  SAFE_QUERY_MINT=$(operator sc query ${SAFE} getMintBalances --args String:$TOKEN --node=${PROXY})
+  EXISTING_MINT=$(echo $SAFE_QUERY_MINT | jq '.[0].number')
+  
   NEW_MINT=$(echo "$ETH_VALUE+$EXISTING_BURN" | bc)
   DIFF=$(echo "$EXISTING_MINT-$EXISTING_BURN" | bc)
   NEW_DIFF=$(echo "$NEW_MINT-$EXISTING_BURN" | bc)
@@ -272,23 +237,24 @@ syncValueWithEthereumDenom() {
   echo "For token ${TOKEN} the existing mint is ${EXISTING_MINT} and existing burn is ${EXISTING_BURN}. The minted value will be replaced with ${NEW_MINT}"
   echo "Existing diff ${DIFF}, new diff will be ${NEW_DIFF}"
 
-  mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="initSupplyMintBurnEsdtSafe" \
-    --arguments str:${TOKEN} ${NEW_MINT} ${EXISTING_BURN} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+  operator sc invoke ${MULTISIG} initSupplyMintBurnKdaSafe --key-file=${ALICE} \
+    --args String:${TOKEN} n:${NEW_MINT} n:${EXISTING_BURN} \
+    --await --sign --node ${PROXY}
 }
 
 upgradeMultisig() {
-    CHECK_VARIABLES SAFE MULTI_TRANSFER BRIDGE_PROXY MULTISIG_WASM
+    CHECK_VARIABLES SAFE MULTI_TRANSFER MULTISIG_WASM
 
-    mxpy contract upgrade ${MULTISIG} --bytecode=${MULTISIG_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-      --gas-limit=100000000 --send \
-      --arguments ${SAFE} ${MULTI_TRANSFER} ${BRIDGE_PROXY} \
-      --outfile="upgrade-multisig-child-sc.json" --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    SC_RESULT=$(eval operator sc upgrade ${MULTISIG} --key-file=${ALICE} \
+    --wasm ${MULTISIG_WASM} \
+    --args A:${SAFE} A:${MULTI_TRANSFER} \
+    --await --result-only --sign --node ${PROXY} \
 
-    TRANSACTION=$(mxpy data parse --file="./upgrade-multisig-child-sc.json" --expression="data['emitted_tx']['hash']")
-    ADDRESS=$(mxpy data parse --file="./upgrade-multisig-child-sc.json" --expression="data['contractAddress']")
+    check_result ${SC_RESULT}
+
+    CONTRACT_ADDRESS=$(jq '.logs.events[] | select(.identifier=="SCDeploy") | .address' <<< "${SC_RESULT}")
+    CONTRACT_ADDRESS=$(echo ${CONTRACT_ADDRESS} | tr -d '"')
 
     echo ""
-    echo "Multisig contract updated: ${ADDRESS}"
+    echo "Multisig contract upgraded successfully at address: ${CONTRACT_ADDRESS}"
 }

--- a/multisig/interaction/config/multisig-snippets.sh
+++ b/multisig/interaction/config/multisig-snippets.sh
@@ -6,9 +6,9 @@ deployMultisig() {
     MIN_STAKE=$(echo "$RELAYER_REQUIRED_STAKE*10^18" | bc)
     
     SC_RESULT=$(eval operator sc create --key-file=${ALICE} --wasm ${MULTISIG_WASM} \
-    --args A:${SAFE} A:${MULTI_TRANSFER} \
-    n:${MIN_STAKE} n:${SLASH_AMOUNT} n:${QUORUM} \
-    A:${RELAYER_ADDR_0} A:${RELAYER_ADDR_1} A:${RELAYER_ADDR_2} A:${RELAYER_ADDR_3} \
+    --args A:${SAFE} --args A:${MULTI_TRANSFER} \
+    --args n:${MIN_STAKE} --args n:${SLASH_AMOUNT} --args n:${QUORUM} \
+    --args A:${RELAYER_ADDR_0} --args A:${RELAYER_ADDR_1} --args A:${RELAYER_ADDR_2} --args A:${RELAYER_ADDR_3} \
     --await --result-only --sign --node ${PROXY})
 
     check_result ${SC_RESULT}
@@ -41,7 +41,7 @@ clearMapping() {
     CHECK_VARIABLES ERC20_TOKEN CHAIN_SPECIFIC_TOKEN MULTISIG
 
     operator sc invoke ${MULTISIG} clearMapping --key-file=${ALICE} \
-    --args A:${ERC20_TOKEN} String:${CHAIN_SPECIFIC_TOKEN} \
+    --args A:${ERC20_TOKEN} --args String:${CHAIN_SPECIFIC_TOKEN} \
     --await --sign --node ${PROXY}
 }
 
@@ -49,7 +49,7 @@ addMapping() {
     CHECK_VARIABLES ERC20_TOKEN CHAIN_SPECIFIC_TOKEN MULTISIG
 
     operator sc invoke ${MULTISIG} addMapping --key-file=${ALICE} \
-    --args A:${ERC20_TOKEN} String:${CHAIN_SPECIFIC_TOKEN} \
+    --args A:${ERC20_TOKEN} --args String:${CHAIN_SPECIFIC_TOKEN} \
     --await --sign --node ${PROXY}
 }
 
@@ -61,8 +61,8 @@ addTokenToWhitelist() {
     BURN=$(echo "$BURN_BALANCE*10^$NR_DECIMALS_CHAIN_SPECIFIC" | bc)
 
     operator sc invoke ${MULTISIG} kdaSafeAddTokenToWhitelist --key-file=${ALICE} \
-    --args String:${CHAIN_SPECIFIC_TOKEN} String:${CHAIN_SPECIFIC_TOKEN_TICKER} A:${MINTBURN_WHITELIST} n:${NATIVE_TOKEN} \
-    n:${BALANCE} n:${MINT} n:${BURN} \
+    --args String:${CHAIN_SPECIFIC_TOKEN} --args String:${CHAIN_SPECIFIC_TOKEN_TICKER} --args A:${MINTBURN_WHITELIST} --args n:${NATIVE_TOKEN} \
+    --args n:${BALANCE} --args n:${MINT} --args n:${BURN} \
     --await --sign --node ${PROXY}
 }
 
@@ -160,7 +160,7 @@ kdaSafeSetMaxBridgedAmountForToken() {
     MAX=$(echo "scale=0; $MAX_AMOUNT*10^$NR_DECIMALS_CHAIN_SPECIFIC/1" | bc)
     
     operator sc invoke ${MULTISIG} kdaSafeSetMaxBridgedAmountForToken --key-file=${ALICE} \
-    --args String:${CHAIN_SPECIFIC_TOKEN} n:${MAX} \
+    --args String:${CHAIN_SPECIFIC_TOKEN} --args n:${MAX} \
     --await --sign --node ${PROXY}
 }
 
@@ -170,7 +170,7 @@ multiTransferKdaSetMaxBridgedAmountForToken() {
     MAX=$(echo "scale=0; $MAX_AMOUNT*10^$NR_DECIMALS_CHAIN_SPECIFIC/1" | bc)
     
     operator sc invoke ${MULTISIG} multiTransferKdaSetMaxBridgedAmountForToken --key-file=${ALICE} \
-    --args String:${CHAIN_SPECIFIC_TOKEN} n:${MAX} \
+    --args String:${CHAIN_SPECIFIC_TOKEN} --args n:${MAX} \
     --await --sign --node ${PROXY}
 }
 
@@ -178,7 +178,7 @@ multiTransferKdaSetMaxBridgedAmountForTokenWithRAWValue() {
     CHECK_VARIABLES ETH_MAX_AMOUNT CHAIN_SPECIFIC_TOKEN MULTISIG
 
     operator sc invoke ${MULTISIG} multiTransferKdaSetMaxBridgedAmountForToken --key-file=${ALICE} \
-    --args String:${CHAIN_SPECIFIC_TOKEN} n:${ETH_MAX_AMOUNT} \
+    --args String:${CHAIN_SPECIFIC_TOKEN} --args n:${ETH_MAX_AMOUNT} \
     --await --sign --node ${PROXY}
 }
 
@@ -213,7 +213,7 @@ initSupplyMintBurn() {
   BURN=$(echo ${BURN%.*}) # trim decimals, if existing
 
   operator sc invoke ${MULTISIG} initSupplyMintBurnKdaSafe --key-file=${ALICE} \
-  --args String:${CHAIN_SPECIFIC_TOKEN} n:${MINT} n:${BURN} \
+  --args String:${CHAIN_SPECIFIC_TOKEN} --args n:${MINT} --args n:${BURN} \
   --await --sign --node ${PROXY}
 }
 
@@ -238,7 +238,7 @@ syncValueWithEthereumDenom() {
   echo "Existing diff ${DIFF}, new diff will be ${NEW_DIFF}"
 
   operator sc invoke ${MULTISIG} initSupplyMintBurnKdaSafe --key-file=${ALICE} \
-    --args String:${TOKEN} n:${NEW_MINT} n:${EXISTING_BURN} \
+    --args String:${TOKEN} --args n:${NEW_MINT} --args n:${EXISTING_BURN} \
     --await --sign --node ${PROXY}
 }
 
@@ -254,7 +254,7 @@ upgradeMultisig() {
 
     CONTRACT_ADDRESS=$(jq '.logs.events[] | select(.identifier=="SCDeploy") | .address' <<< "${SC_RESULT}")
     CONTRACT_ADDRESS=$(echo ${CONTRACT_ADDRESS} | tr -d '"')
-
+    
     echo ""
     echo "Multisig contract upgraded successfully at address: ${CONTRACT_ADDRESS}"
 }

--- a/multisig/interaction/config/multitransfer-snippets.sh
+++ b/multisig/interaction/config/multitransfer-snippets.sh
@@ -1,55 +1,51 @@
 deployMultiTransfer() {
     CHECK_VARIABLES MULTI_TRANSFER_WASM
 
-    mxpy contract deploy --bytecode=${MULTI_TRANSFER_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=100000000 --metadata-payable \
-    --send --outfile="deploy-multitransfer-testnet.interaction.json" --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    SC_RESULT=$(eval operator sc create --key-file=${ALICE} --wasm ${MULTI_TRANSFER_WASM} \
+    --await --result-only --sign --node ${PROXY})
 
-    ADDRESS=$(mxpy data parse --file="./deploy-multitransfer-testnet.interaction.json" --expression="data['contractAddress']")
-    mxpy data store --key=address-testnet-multitransfer --value=${ADDRESS}
+    check_result ${SC_RESULT}
+
+    CONTRACT_ADDRESS=$(jq '.logs.events[] | select(.identifier=="SCDeploy") | .address' <<< "${SC_RESULT}")
+    CONTRACT_ADDRESS=$(echo ${CONTRACT_ADDRESS} | tr -d '"')
 
     echo ""
-    echo "Multi transfer contract address: ${ADDRESS}"
-    update-config MULTI_TRANSFER ${ADDRESS}
-}
-
-setBridgeProxyContractAddressOnMultiTransfer() {
-    CHECK_VARIABLES MULTI_TRANSFER BRIDGE_PROXY
-
-    mxpy contract call ${MULTI_TRANSFER} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="setBridgeProxyContractAddress" \
-    --arguments ${BRIDGE_PROXY} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    echo "Multi transfer contract address: ${CONTRACT_ADDRESS}"
+    update-config MULTI_TRANSFER ${CONTRACT_ADDRESS}
 }
 
 setBridgedTokensWrapperOnMultiTransfer() {
     CHECK_VARIABLES MULTI_TRANSFER BRIDGED_TOKENS_WRAPPER
 
-    mxpy contract call ${MULTI_TRANSFER} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="setWrappingContractAddress" \
-    --arguments ${BRIDGED_TOKENS_WRAPPER} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTI_TRANSFER} setWrappingContractAddress --key-file=${ALICE} \
+    --args A:${BRIDGED_TOKENS_WRAPPER} \
+    --await --sign --node ${PROXY}
 }
 
 deployMultiTransferForUpgrade() {
     CHECK_VARIABLES MULTI_TRANSFER_WASM
 
-    mxpy contract deploy --bytecode=${MULTI_TRANSFER_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-        --gas-limit=100000000 --metadata-payable \
-        --send --outfile="deploy-multitransfer-upgrade.interaction.json" --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    SC_RESULT=$(eval operator sc create --key-file=${ALICE} --wasm ${MULTI_TRANSFER_WASM} \
+    --await --result-only --sign --node ${PROXY})
 
-    TRANSACTION=$(mxpy data parse --file="./deploy-multitransfer-upgrade.interaction.json" --expression="data['emittedTransactionHash']")
-    ADDRESS=$(mxpy data parse --file="./deploy-multitransfer-upgrade.interaction.json" --expression="data['contractAddress']")
+    check_result ${SC_RESULT}
+
+    CONTRACT_ADDRESS=$(jq '.logs.events[] | select(.identifier=="SCDeploy") | .address' <<< "${SC_RESULT}")
+    CONTRACT_ADDRESS=$(echo ${CONTRACT_ADDRESS} | tr -d '"')
 
     echo ""
-    echo "New multi transfer contract address: ${ADDRESS}"
+    echo "New multi transfer contract address: ${CONTRACT_ADDRESS}"
+    
+    # Store for later use in upgradeMultiTransferContract
+    NEW_MULTI_TRANSFER_ADDR=${CONTRACT_ADDRESS}
 }
 
 upgradeMultiTransferContract() {
-    local NEW_MULTI_TRANSFER_ADDR=$(mxpy data parse --file="./deploy-multitransfer-upgrade.interaction.json" --expression="data['contractAddress']")
+    CHECK_VARIABLES MULTISIG MULTI_TRANSFER NEW_MULTI_TRANSFER_ADDR
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=400000000 --function="upgradeChildContractFromSource" \
-    --arguments ${MULTI_TRANSFER} ${NEW_MULTI_TRANSFER_ADDR} 0x00 \
-    --send --outfile="upgrade-multitransfer-child-sc.json" --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} upgradeChildContractFromSource --key-file=${ALICE} \
+    --args A:${MULTI_TRANSFER} --args A:${NEW_MULTI_TRANSFER_ADDR} --args bool:false \
+    --await --sign --node ${PROXY}
+
+    update-config MULTI_TRANSFER ${NEW_MULTI_TRANSFER_ADDR}
 }

--- a/multisig/interaction/config/multitransfer-snippets.sh
+++ b/multisig/interaction/config/multitransfer-snippets.sh
@@ -49,3 +49,11 @@ upgradeMultiTransferContract() {
 
     update-config MULTI_TRANSFER ${NEW_MULTI_TRANSFER_ADDR}
 }
+
+addAdminToMultiTransfer(){
+    CHECK_VARIABLES MULTI_TRANSFER
+
+    operator sc invoke ${MULTI_TRANSFER} addAdmin --key-file=${ALICE} \
+    --args A:${ALICE_ADDRESS} \
+    --await --sign --node ${PROXY}
+}

--- a/multisig/interaction/config/proxy-snippets.sh
+++ b/multisig/interaction/config/proxy-snippets.sh
@@ -1,69 +1,69 @@
 deployBridgeProxy() {
     CHECK_VARIABLES PROXY_WASM MULTI_TRANSFER
 
-    mxpy contract deploy --bytecode=${PROXY_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=200000000 \
-    --arguments ${MULTI_TRANSFER} \
-    --send --outfile="deploy-proxy-testnet.interaction.json" --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    SC_RESULT=$(eval operator sc create --key-file=${ALICE} --wasm ${PROXY_WASM} \
+    --args A:${MULTI_TRANSFER} \
+    --await --result-only --sign --node ${PROXY})
 
-    TRANSACTION=$(mxpy data parse --file="./deploy-proxy-testnet.interaction.json" --expression="data['emitted_tx']['hash']")
-    ADDRESS=$(mxpy data parse --file="./deploy-proxy-testnet.interaction.json" --expression="data['contractAddress']")
+    check_result ${SC_RESULT}
 
-    # mxpy data store --key=address-testnet-proxy --value=${ADDRESS}
-    # mxpy data store --key=deployTransaction-testnet --value=${TRANSACTION}
+    CONTRACT_ADDRESS=$(jq '.logs.events[] | select(.identifier=="SCDeploy") | .address' <<< "${SC_RESULT}")
+    CONTRACT_ADDRESS=$(echo ${CONTRACT_ADDRESS} | tr -d '"')
 
     echo ""
-    echo "Proxy contract address: ${ADDRESS}"
-    update-config BRIDGE_PROXY ${ADDRESS}
+    echo "Proxy contract address: ${CONTRACT_ADDRESS}"
+    update-config BRIDGE_PROXY ${CONTRACT_ADDRESS}
 }
 
 setBridgedTokensWrapperOnSCProxy() {
     CHECK_VARIABLES BRIDGE_PROXY BRIDGED_TOKENS_WRAPPER
 
-    mxpy contract call ${BRIDGE_PROXY} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="setBridgedTokensWrapperAddress" \
-    --arguments ${BRIDGED_TOKENS_WRAPPER} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${BRIDGE_PROXY} setBridgedTokensWrapperAddress --key-file=${ALICE} \
+    --args A:${BRIDGED_TOKENS_WRAPPER} \
+    --await --sign --node ${PROXY}
 }
 
 setMultiTransferOnSCProxy() {
     CHECK_VARIABLES BRIDGE_PROXY MULTI_TRANSFER
 
-    mxpy contract call ${BRIDGE_PROXY} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="setMultiTransferAddress" \
-    --arguments ${MULTI_TRANSFER} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${BRIDGE_PROXY} setMultiTransferAddress --key-file=${ALICE} \
+    --args A:${MULTI_TRANSFER} \
+    --await --sign --node ${PROXY}
 }
 
-setEsdtSafeOnSCProxy() {
+setKdaSafeOnSCProxy() {
     CHECK_VARIABLES BRIDGE_PROXY SAFE
 
-    mxpy contract call ${BRIDGE_PROXY} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="setEsdtSafeAddress" \
-    --arguments ${SAFE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${BRIDGE_PROXY} setKdaSafeAddress --key-file=${ALICE} \
+    --args A:${SAFE} \
+    --await --sign --node ${PROXY}
 }
 
 deployBridgeProxyForUpgrade() {
     CHECK_VARIABLES PROXY_WASM MULTI_TRANSFER
 
-    mxpy contract deploy --bytecode=${PROXY_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-        --gas-limit=200000000 \
-        --arguments ${MULTI_TRANSFER} \
-        --send --outfile="deploy-proxy-upgrade.interaction.json" --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    SC_RESULT=$(eval operator sc create --key-file=${ALICE} --wasm ${PROXY_WASM} \
+    --args A:${MULTI_TRANSFER} \
+    --await --result-only --sign --node ${PROXY})
 
-    TRANSACTION=$(mxpy data parse --file="./deploy-proxy-upgrade.interaction.json" --expression="data['emittedTransactionHash']")
-    ADDRESS=$(mxpy data parse --file="./deploy-proxy-upgrade.interaction.json" --expression="data['contractAddress']")
+    check_result ${SC_RESULT}
+
+    CONTRACT_ADDRESS=$(jq '.logs.events[] | select(.identifier=="SCDeploy") | .address' <<< "${SC_RESULT}")
+    CONTRACT_ADDRESS=$(echo ${CONTRACT_ADDRESS} | tr -d '"')
 
     echo ""
-    echo "New proxy contract address: ${ADDRESS}"
+    echo "New proxy contract address: ${CONTRACT_ADDRESS}"
+    
+    # Store for later use in upgradeBridgeProxyContract
+    NEW_BRIDGE_PROXY_ADDR=${CONTRACT_ADDRESS}
 }
 
 upgradeBridgeProxyContract() {
-    local NEW_BRIDGE_PROXY_ADDR=$(mxpy data parse --file="./deploy-proxy-upgrade.interaction.json" --expression="data['contractAddress']")
+    CHECK_VARIABLES MULTISIG BRIDGE_PROXY NEW_BRIDGE_PROXY_ADDR
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=400000000 --function="upgradeChildContractFromSource" \
-    --arguments ${BRIDGE_PROXY} ${NEW_BRIDGE_PROXY_ADDR} 0x00 \
-    --send --outfile="upgrade-proxy-child-sc.json" --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} upgradeChildContractFromSource --key-file=${ALICE} \
+    --args A:${BRIDGE_PROXY} --args A:${NEW_BRIDGE_PROXY_ADDR} --args bool:false \
+    --await --sign --node ${PROXY}
+
+    update-config BRIDGE_PROXY ${NEW_BRIDGE_PROXY_ADDR}
 }

--- a/multisig/interaction/config/relayers-snippets.sh
+++ b/multisig/interaction/config/relayers-snippets.sh
@@ -2,29 +2,29 @@ addBoardMember() {
     CHECK_VARIABLES MULTISIG
 
     read -p "Relayer address: " RELAYER_ADDR
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=35000000 --function="addBoardMember" --arguments ${RELAYER_ADDR} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} addBoardMember --key-file=${ALICE} \
+    --args A:${RELAYER_ADDR} \
+    --await --sign --node ${PROXY}
 }
 
 removeBoardMember() {
     CHECK_VARIABLES MULTISIG
 
     read -p "Relayer address: " RELAYER_ADDR
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=35000000 --function="removeUser" --arguments ${RELAYER_ADDR} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} removeUser --key-file=${ALICE} \
+    --args A:${RELAYER_ADDR} \
+    --await --sign --node ${PROXY}
 }
 
 unstake() {
     CHECK_VARIABLES MULTISIG RELAYER_REQUIRED_STAKE
 
     read -p "Relayer address: " RELAYER_ADDR
-    MIN_STAKE=$(echo "$RELAYER_REQUIRED_STAKE*10^18" | bc)
-    mxpy --verbose contract call ${MULTISIG} --recall-nonce --pem="./walletsRelay/${RELAYER_ADDR}.pem" \
-    --gas-limit=35000000 --function="unstake" \
-    --arguments ${MIN_STAKE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    MIN_STAKE=$(echo "$RELAYER_REQUIRED_STAKE*10^6" | bc)
+    
+    operator sc invoke ${MULTISIG} unstake --key-file="./walletsRelay/${RELAYER_ADDR}.pem" \
+    --args n:${MIN_STAKE} \
+    --await --sign --node ${PROXY}
 }
 
 stakeRelayers() {
@@ -32,53 +32,64 @@ stakeRelayers() {
     RELAYER_WALLET0 RELAYER_WALLET1 RELAYER_WALLET2 RELAYER_WALLET3 RELAYER_WALLET4 \
     RELAYER_WALLET5 RELAYER_WALLET6 RELAYER_WALLET7 RELAYER_WALLET8 RELAYER_WALLET9
 
-    MIN_STAKE=$(echo "$RELAYER_REQUIRED_STAKE*10^18" | bc)
-    mxpy --verbose contract call ${MULTISIG} --recall-nonce --pem=${RELAYER_WALLET0} \
-    --gas-limit=35000000 --function="stake" --value=${MIN_STAKE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    MIN_STAKE=$(echo "$RELAYER_REQUIRED_STAKE*10^6" | bc)
+    
+    echo "Staking relayer 0..."
+    operator sc invoke ${MULTISIG} stake --key-file=${RELAYER_WALLET0} \
+    --values "KLV=${MIN_STAKE}" \
+    --await --sign --node ${PROXY}
     echo "---------------------------------------------------------"
+    
+    echo "Staking relayer 1..."
+    operator sc invoke ${MULTISIG} stake --key-file=${RELAYER_WALLET1} \
+    --values "KLV=${MIN_STAKE}" \
+    --await --sign --node ${PROXY}
     echo "---------------------------------------------------------"
-    mxpy --verbose contract call ${MULTISIG} --recall-nonce --pem=${RELAYER_WALLET1} \
-    --gas-limit=35000000 --function="stake" --value=${MIN_STAKE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    
+    echo "Staking relayer 2..."
+    operator sc invoke ${MULTISIG} stake --key-file=${RELAYER_WALLET2} \
+    --values "KLV=${MIN_STAKE}" \
+    --await --sign --node ${PROXY}
     echo "---------------------------------------------------------"
+    
+    echo "Staking relayer 3..."
+    operator sc invoke ${MULTISIG} stake --key-file=${RELAYER_WALLET3} \
+    --values "KLV=${MIN_STAKE}" \
+    --await --sign --node ${PROXY}
     echo "---------------------------------------------------------"
-    mxpy --verbose contract call ${MULTISIG} --recall-nonce --pem=${RELAYER_WALLET2} \
-    --gas-limit=35000000 --function="stake" --value=${MIN_STAKE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    
+    echo "Staking relayer 4..."
+    operator sc invoke ${MULTISIG} stake --key-file=${RELAYER_WALLET4} \
+    --values "KLV=${MIN_STAKE}" \
+    --await --sign --node ${PROXY}
     echo "---------------------------------------------------------"
+    
+    echo "Staking relayer 5..."
+    operator sc invoke ${MULTISIG} stake --key-file=${RELAYER_WALLET5} \
+    --values "KLV=${MIN_STAKE}" \
+    --await --sign --node ${PROXY}
     echo "---------------------------------------------------------"
-    mxpy --verbose contract call ${MULTISIG} --recall-nonce --pem=${RELAYER_WALLET3} \
-    --gas-limit=35000000 --function="stake" --value=${MIN_STAKE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    
+    echo "Staking relayer 6..."
+    operator sc invoke ${MULTISIG} stake --key-file=${RELAYER_WALLET6} \
+    --values "KLV=${MIN_STAKE}" \
+    --await --sign --node ${PROXY}
     echo "---------------------------------------------------------"
+    
+    echo "Staking relayer 7..."
+    operator sc invoke ${MULTISIG} stake --key-file=${RELAYER_WALLET7} \
+    --values "KLV=${MIN_STAKE}" \
+    --await --sign --node ${PROXY}
     echo "---------------------------------------------------------"
-    mxpy --verbose contract call ${MULTISIG} --recall-nonce --pem=${RELAYER_WALLET4} \
-    --gas-limit=35000000 --function="stake" --value=${MIN_STAKE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    
+    echo "Staking relayer 8..."
+    operator sc invoke ${MULTISIG} stake --key-file=${RELAYER_WALLET8} \
+    --values "KLV=${MIN_STAKE}" \
+    --await --sign --node ${PROXY}
     echo "---------------------------------------------------------"
-    echo "---------------------------------------------------------"
-    mxpy --verbose contract call ${MULTISIG} --recall-nonce --pem=${RELAYER_WALLET5} \
-    --gas-limit=35000000 --function="stake" --value=${MIN_STAKE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
-    echo "---------------------------------------------------------"
-    echo "---------------------------------------------------------"
-    mxpy --verbose contract call ${MULTISIG} --recall-nonce --pem=${RELAYER_WALLET6} \
-    --gas-limit=35000000 --function="stake" --value=${MIN_STAKE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
-    echo "---------------------------------------------------------"
-    echo "---------------------------------------------------------"
-    mxpy --verbose contract call ${MULTISIG} --recall-nonce --pem=${RELAYER_WALLET7} \
-    --gas-limit=35000000 --function="stake" --value=${MIN_STAKE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
-    echo "---------------------------------------------------------"
-    echo "---------------------------------------------------------"
-    mxpy --verbose contract call ${MULTISIG} --recall-nonce --pem=${RELAYER_WALLET8} \
-    --gas-limit=35000000 --function="stake" --value=${MIN_STAKE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
-    echo "---------------------------------------------------------"
-    echo "---------------------------------------------------------"
-    mxpy --verbose contract call ${MULTISIG} --recall-nonce --pem=${RELAYER_WALLET9} \
-    --gas-limit=35000000 --function="stake" --value=${MIN_STAKE} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    
+    echo "Staking relayer 9..."
+    operator sc invoke ${MULTISIG} stake --key-file=${RELAYER_WALLET9} \
+    --values "KLV=${MIN_STAKE}" \
+    --await --sign --node ${PROXY}
 }

--- a/multisig/interaction/config/safe-snippets.sh
+++ b/multisig/interaction/config/safe-snippets.sh
@@ -17,17 +17,21 @@ deploySafe() {
 
 setLocalRolesKdaSafe() {
     CHECK_VARIABLES CHAIN_SPECIFIC_TOKEN SAFE
-    ADD_ROLE_TRIGGER=6
+    
+    # Trigger 6: AddRole - Add a permission role to the asset
+    local TRIGGER_ADD_ROLE=6
 
-    operator kda trigger ${ADD_ROLE_TRIGGER} --kdaID=${CHAIN_SPECIFIC_TOKEN} --addRolesMint=${SAFE} --key-file=${ALICE} \
+    operator kda trigger ${TRIGGER_ADD_ROLE} --kdaID=${CHAIN_SPECIFIC_TOKEN} --addRolesMint=${SAFE} --key-file=${ALICE} \
     --await --sign --node ${PROXY}
 }
 
 unsetLocalRolesKdaSafe() {
     CHECK_VARIABLES CHAIN_SPECIFIC_TOKEN SAFE
-    REMOVE_ROLE_TRIGGER=7
+    
+    # Trigger 7: RemoveRole - Remove a permission role of the asset
+    local TRIGGER_REMOVE_ROLE=7
 
-    operator kda trigger ${REMOVE_ROLE_TRIGGER} --kdaID=${CHAIN_SPECIFIC_TOKEN} --key-file=${ALICE} \
+    operator kda trigger ${TRIGGER_REMOVE_ROLE} --kdaID=${CHAIN_SPECIFIC_TOKEN} --key-file=${ALICE} \
     --await --sign --node ${PROXY}
 }
 

--- a/multisig/interaction/config/safe-snippets.sh
+++ b/multisig/interaction/config/safe-snippets.sh
@@ -72,3 +72,11 @@ upgradeSafeContract() {
 
     update-config SAFE ${NEW_SAFE_ADDR}
 }
+
+addAdminToKdaSafe(){
+    CHECK_VARIABLES SAFE
+
+    operator sc invoke ${SAFE} addAdmin --key-file=${ALICE} \
+    --args A:${ALICE_ADDRESS} \
+    --await --sign --node ${PROXY}
+}

--- a/multisig/interaction/config/safe-snippets.sh
+++ b/multisig/interaction/config/safe-snippets.sh
@@ -1,79 +1,70 @@
 deploySafe() {
     CHECK_VARIABLES SAFE_WASM MULTI_TRANSFER AGGREGATOR
     
-    mxpy contract deploy --bytecode=${SAFE_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=150000000 \
-    --arguments ${AGGREGATOR} ${MULTI_TRANSFER} 1 \
-    --send --outfile="deploy-safe-testnet.interaction.json" --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    SC_RESULT=$(eval operator sc create --key-file=${ALICE} --wasm ${SAFE_WASM} \
+    --args A:${AGGREGATOR} --args A:${MULTI_TRANSFER} --args n:1 \
+    --await --result-only --sign --node ${PROXY})
 
-    TRANSACTION=$(mxpy data parse --file="./deploy-safe-testnet.interaction.json" --expression="data['emittedTransactionHash']")
-    ADDRESS=$(mxpy data parse --file="./deploy-safe-testnet.interaction.json" --expression="data['contractAddress']")
+    check_result ${SC_RESULT}
 
-    mxpy data store --key=address-testnet-safe --value=${ADDRESS}
-    mxpy data store --key=deployTransaction-testnet --value=${TRANSACTION}
+    CONTRACT_ADDRESS=$(jq '.logs.events[] | select(.identifier=="SCDeploy") | .address' <<< "${SC_RESULT}")
+    CONTRACT_ADDRESS=$(echo ${CONTRACT_ADDRESS} | tr -d '"')
 
     echo ""
-    echo "Safe contract address: ${ADDRESS}"
-    update-config SAFE ${ADDRESS}
+    echo "Safe contract address: ${CONTRACT_ADDRESS}"
+    update-config SAFE ${CONTRACT_ADDRESS}
 }   
 
-setLocalRolesEsdtSafe() {
-    CHECK_VARIABLES ESDT_SYSTEM_SC_ADDRESS CHAIN_SPECIFIC_TOKEN SAFE
+setLocalRolesKdaSafe() {
+    CHECK_VARIABLES CHAIN_SPECIFIC_TOKEN SAFE
+    ADD_ROLE_TRIGGER=6
 
-    mxpy contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="setSpecialRole" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN} ${SAFE} str:ESDTRoleLocalBurn str:ESDTRoleLocalMint \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator kda trigger ${ADD_ROLE_TRIGGER} --kdaID=${CHAIN_SPECIFIC_TOKEN} --addRolesMint=${SAFE} --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
-unsetLocalRolesEsdtSafe() {
-    CHECK_VARIABLES ESDT_SYSTEM_SC_ADDRESS CHAIN_SPECIFIC_TOKEN SAFE
+unsetLocalRolesKdaSafe() {
+    CHECK_VARIABLES CHAIN_SPECIFIC_TOKEN SAFE
+    REMOVE_ROLE_TRIGGER=7
 
-    mxpy contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="unSetSpecialRole" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN} ${SAFE} str:ESDTRoleLocalBurn str:ESDTRoleLocalMint \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator kda trigger ${REMOVE_ROLE_TRIGGER} --kdaID=${CHAIN_SPECIFIC_TOKEN} --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
-setBridgedTokensWrapperOnEsdtSafe() {
+setBridgedTokensWrapperOnKdaSafe() {
     CHECK_VARIABLES SAFE BRIDGED_TOKENS_WRAPPER
 
-    mxpy contract call ${SAFE} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="setBridgedTokensWrapperAddress" \
-    --arguments ${BRIDGED_TOKENS_WRAPPER} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
-}
-
-setSCProxyOnEsdtSafe() {
-    CHECK_VARIABLES SAFE BRIDGE_PROXY
-
-    mxpy contract call ${SAFE} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="setBridgeProxyContractAddress" \
-    --arguments ${BRIDGE_PROXY} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${SAFE} setBridgedTokensWrapperAddress --key-file=${ALICE} \
+    --args A:${BRIDGED_TOKENS_WRAPPER} \
+    --await --sign --node ${PROXY}
 }
 
 deploySafeForUpgrade() {
-    CHECK_VARIABLES SAFE_WASM MULTI_TRANSFER AGGREGATOR BRIDGE_PROXY
+    CHECK_VARIABLES SAFE_WASM MULTI_TRANSFER AGGREGATOR
 
-    mxpy contract deploy --bytecode=${SAFE_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=150000000 \
-    --arguments ${AGGREGATOR} ${MULTI_TRANSFER} 1 \
-    --send --outfile="deploy-safe-upgrade.interaction.json" --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    SC_RESULT=$(eval operator sc create --key-file=${ALICE} --wasm ${SAFE_WASM} \
+    --args A:${AGGREGATOR} --args A:${MULTI_TRANSFER} --args n:1 \
+    --await --result-only --sign --node ${PROXY})
 
-    TRANSACTION=$(mxpy data parse --file="./deploy-safe-upgrade.interaction.json" --expression="data['emittedTransactionHash']")
-    ADDRESS=$(mxpy data parse --file="./deploy-safe-upgrade.interaction.json" --expression="data['contractAddress']")
+    check_result ${SC_RESULT}
+
+    CONTRACT_ADDRESS=$(jq '.logs.events[] | select(.identifier=="SCDeploy") | .address' <<< "${SC_RESULT}")
+    CONTRACT_ADDRESS=$(echo ${CONTRACT_ADDRESS} | tr -d '"')
 
     echo ""
-    echo "New safe contract address: ${ADDRESS}"
+    echo "New safe contract address: ${CONTRACT_ADDRESS}"
+    
+    # Store for later use in upgradeSafeContract
+    NEW_SAFE_ADDR=${CONTRACT_ADDRESS}
 }
 
 upgradeSafeContract() {
-    local NEW_SAFE_ADDR=$(mxpy data parse --file="./deploy-safe-upgrade.interaction.json" --expression="data['contractAddress']")
+    CHECK_VARIABLES MULTISIG SAFE NEW_SAFE_ADDR AGGREGATOR MULTI_TRANSFER
 
-    mxpy contract call ${MULTISIG} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=400000000 --function="upgradeChildContractFromSource" \
-    --arguments ${SAFE} ${NEW_SAFE_ADDR} 0x00 \
-    ${AGGREGATOR} ${MULTI_TRANSFER} ${BRIDGE_PROXY} 1 \
-    --send --outfile="upgrade-safe-child-sc.json" --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${MULTISIG} upgradeChildContractFromSource --key-file=${ALICE} \
+    --args A:${SAFE} --args A:${NEW_SAFE_ADDR} --args bool:true \
+    --args A:${AGGREGATOR} --args A:${MULTI_TRANSFER} --args n:1 \
+    --await --sign --node ${PROXY}
+
+    update-config SAFE ${NEW_SAFE_ADDR}
 }

--- a/multisig/interaction/config/testing.sh
+++ b/multisig/interaction/config/testing.sh
@@ -1,71 +1,66 @@
 deployFaucet() {
     CHECK_VARIABLES FAUCET_WASM ALICE
 
-    mxpy contract deploy --bytecode=${FAUCET_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=20000000 \
-    --send --outfile=deploy-faucet-testnet.interaction.json --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    SC_RESULT=$(eval operator sc create --key-file=${ALICE} --wasm ${FAUCET_WASM} \
+    --await --result-only --sign --node ${PROXY})
 
-    TRANSACTION=$(mxpy data parse --file="./deploy-faucet-testnet.interaction.json" --expression="data['emittedTransactionHash']")
-    ADDRESS=$(mxpy data parse --file="./deploy-faucet-testnet.interaction.json" --expression="data['contractAddress']")
+    check_result ${SC_RESULT}
 
-    mxpy data store --key=address-testnet-faucet --value=${ADDRESS}
-    mxpy data store --key=deployTransaction-testnet --value=${TRANSACTION}
+    CONTRACT_ADDRESS=$(jq '.logs.events[] | select(.identifier=="SCDeploy") | .address' <<< "${SC_RESULT}")
+    CONTRACT_ADDRESS=$(echo ${CONTRACT_ADDRESS} | tr -d '"')
 
     echo ""
-    echo "Faucet: ${ADDRESS}"
-    update-config FAUCET ${ADDRESS}
+    echo "Faucet contract address: ${CONTRACT_ADDRESS}"
+    update-config FAUCET ${CONTRACT_ADDRESS}
 }
 
 setMintRoleForUniversalToken() {
-  CHECK_VARIABLES ALICE ALICE_ADDRESS
+    CHECK_VARIABLES UNIVERSAL_TOKEN ALICE_ADDRESS
+    
+    # Trigger 6: AddRole - Add a permission role to the asset
+    local TRIGGER_ADD_ROLE=6
 
-  mxpy contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="setSpecialRole" \
-    --arguments str:${UNIVERSAL_TOKEN} ${ALICE_ADDRESS} str:ESDTRoleLocalMint \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator kda trigger ${TRIGGER_ADD_ROLE} --kdaID=${UNIVERSAL_TOKEN} --addRolesMint=${ALICE_ADDRESS} --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 mintAndDeposit() {
-  CHECK_VARIABLES ALICE ALICE_ADDRESS FAUCET
+    CHECK_VARIABLES FAUCET UNIVERSAL_TOKEN
 
-  read -p "Amount to mint (without decimals): " AMOUNT_TO_MINT
-  VALUE_TO_MINT=$(echo "scale=0; $AMOUNT_TO_MINT*10^$NR_DECIMALS_UNIVERSAL/1" | bc)
-  mxpy contract call ${ALICE_ADDRESS} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=300000 --function="ESDTLocalMint" \
-    --arguments str:${UNIVERSAL_TOKEN} ${VALUE_TO_MINT} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
-
-  sleep 6
-
-  mxpy contract call ${FAUCET} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=5000000 --function="ESDTTransfer" \
-    --arguments str:${UNIVERSAL_TOKEN} ${VALUE_TO_MINT} str:deposit 100 \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    VALUE_TO_MINT=1000000000000000000
+    
+    # Trigger 0: Mint - Directly mint assets in the receiver
+    local TRIGGER_MINT=0
+    
+    operator kda trigger ${TRIGGER_MINT} --kdaID=${UNIVERSAL_TOKEN} --receiver=${ALICE_ADDRESS} --amount=${VALUE_TO_MINT} --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
+    
+    operator sc invoke ${FAUCET} deposit --values ${UNIVERSAL_TOKEN}=${VALUE_TO_MINT} \
+     --key-file=${ALICE} --await --sign --node ${PROXY}
 }
 
 unSetMintRoleForUniversalToken() {
-    CHECK_VARIABLES ALICE ALICE_ADDRESS ESDT_SYSTEM_SC_ADDRESS
+    CHECK_VARIABLES UNIVERSAL_TOKEN
+    
+    # Trigger 7: RemoveRole - Remove a permission role of the asset
+    local TRIGGER_REMOVE_ROLE=7
 
-    mxpy contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="unSetSpecialRole" \
-    --arguments str:${UNIVERSAL_TOKEN} ${ALICE_ADDRESS} str:ESDTRoleLocalMint \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator kda trigger ${TRIGGER_REMOVE_ROLE} --kdaID=${UNIVERSAL_TOKEN} --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 deployTestCaller() {
     CHECK_VARIABLES TEST_CALLER_WASM ALICE
 
-    mxpy contract deploy --bytecode=${TEST_CALLER_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=20000000 \
-    --send --outfile=deploy-test-caller.interaction.json --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    SC_RESULT=$(eval operator sc create --key-file=${ALICE} --wasm ${TEST_CALLER_WASM} \
+    --await --result-only --sign --node ${PROXY})
 
-    TRANSACTION=$(mxpy data parse --file="./deploy-test-caller.interaction.json" --expression="data['emittedTransactionHash']")
-    ADDRESS=$(mxpy data parse --file="./deploy-test-caller.interaction.json" --expression="data['contractAddress']")
+    check_result ${SC_RESULT}
 
-    mxpy data store --key=address-test-caller --value=${ADDRESS}
-    mxpy data store --key=deployTransaction-testnet --value=${TRANSACTION}
+    CONTRACT_ADDRESS=$(jq '.logs.events[] | select(.identifier=="SCDeploy") | .address' <<< "${SC_RESULT}")
+    CONTRACT_ADDRESS=$(echo ${CONTRACT_ADDRESS} | tr -d '"')
 
     echo ""
-    echo "Test caller: ${ADDRESS}"
-    update-config TEST_CALLER ${ADDRESS}
+    echo "Test caller contract address: ${CONTRACT_ADDRESS}"
+    update-config TEST_CALLER ${CONTRACT_ADDRESS}
 }

--- a/multisig/interaction/config/wrapped-snippets.sh
+++ b/multisig/interaction/config/wrapped-snippets.sh
@@ -8,131 +8,115 @@
 deployBridgedTokensWrapper() {
     CHECK_VARIABLES BRIDGED_TOKENS_WRAPPER_WASM
     
-    mxpy contract deploy --bytecode=${BRIDGED_TOKENS_WRAPPER_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 \
-    --send --outfile="deploy-bridged-tokens-wrapper-testnet.interaction.json" --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    SC_RESULT=$(eval operator sc create --key-file=${ALICE} --wasm ${BRIDGED_TOKENS_WRAPPER_WASM} \
+    --await --result-only --sign --node ${PROXY})
 
-    TRANSACTION=$(mxpy data parse --file="./deploy-bridged-tokens-wrapper-testnet.interaction.json" --expression="data['emittedTransactionHash']")
-    ADDRESS=$(mxpy data parse --file="./deploy-bridged-tokens-wrapper-testnet.interaction.json" --expression="data['contractAddress']")
+    check_result ${SC_RESULT}
 
-    mxpy data store --key=address-testnet-bridged-tokens-wrapper --value=${ADDRESS}
-    mxpy data store --key=deployTransaction-testnet --value=${TRANSACTION}
+    CONTRACT_ADDRESS=$(jq '.logs.events[] | select(.identifier=="SCDeploy") | .address' <<< "${SC_RESULT}")
+    CONTRACT_ADDRESS=$(echo ${CONTRACT_ADDRESS} | tr -d '"')
 
     echo ""
-    echo "Bridged tokens wrapper SC: ${ADDRESS}"
-    update-config BRIDGED_TOKENS_WRAPPER ${ADDRESS}
+    echo "Bridged tokens wrapper SC: ${CONTRACT_ADDRESS}"
+    update-config BRIDGED_TOKENS_WRAPPER ${CONTRACT_ADDRESS}
 }
 
 setLocalRolesBridgedTokensWrapper() {
-    CHECK_VARIABLES ESDT_SYSTEM_SC_ADDRESS UNIVERSAL_TOKEN BRIDGED_TOKENS_WRAPPER
+    CHECK_VARIABLES UNIVERSAL_TOKEN BRIDGED_TOKENS_WRAPPER
     
-    mxpy contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="setSpecialRole" \
-    --arguments str:${UNIVERSAL_TOKEN} ${BRIDGED_TOKENS_WRAPPER} str:ESDTRoleLocalMint str:ESDTRoleLocalBurn\
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    # Trigger 6: AddRole - Add a permission role to the asset
+    local TRIGGER_ADD_ROLE=6
+
+    operator kda trigger ${TRIGGER_ADD_ROLE} --kdaID=${UNIVERSAL_TOKEN} --addRolesMint=${BRIDGED_TOKENS_WRAPPER} --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 unsetLocalRolesBridgedTokensWrapper() {
-    CHECK_VARIABLES ESDT_SYSTEM_SC_ADDRESS UNIVERSAL_TOKEN BRIDGED_TOKENS_WRAPPER
+    CHECK_VARIABLES UNIVERSAL_TOKEN BRIDGED_TOKENS_WRAPPER
     
-    mxpy contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=60000000 --function="unSetSpecialRole" \
-    --arguments str:${UNIVERSAL_TOKEN} ${BRIDGED_TOKENS_WRAPPER} str:ESDTRoleLocalMint str:ESDTRoleLocalBurn\
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    # Trigger 7: RemoveRole - Remove a permission role of the asset
+    local TRIGGER_REMOVE_ROLE=7
+
+    operator kda trigger ${TRIGGER_REMOVE_ROLE} --kdaID=${UNIVERSAL_TOKEN} --receiver=${BRIDGED_TOKENS_WRAPPER} --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 addWrappedToken() {
     CHECK_VARIABLES BRIDGED_TOKENS_WRAPPER UNIVERSAL_TOKEN NR_DECIMALS_UNIVERSAL
 
-    mxpy contract call ${BRIDGED_TOKENS_WRAPPER} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=6000000 --function="addWrappedToken" \
-    --arguments str:${UNIVERSAL_TOKEN} ${NR_DECIMALS_UNIVERSAL} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${BRIDGED_TOKENS_WRAPPER} addWrappedToken --key-file=${ALICE} \
+    --args String:${UNIVERSAL_TOKEN} --args u32:${NR_DECIMALS_UNIVERSAL} \
+    --await --sign --node ${PROXY}
 }
 
 removeWrappedToken() {
     CHECK_VARIABLES BRIDGED_TOKENS_WRAPPER UNIVERSAL_TOKEN
 
-    mxpy contract call ${BRIDGED_TOKENS_WRAPPER} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=6000000 --function="removeWrappedToken" \
-    --arguments str:${UNIVERSAL_TOKEN} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
-}
-
-removeWrappedToken() {
-    CHECK_VARIABLES BRIDGED_TOKENS_WRAPPER UNIVERSAL_TOKEN
-
-    mxpy contract call ${BRIDGED_TOKENS_WRAPPER} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=6000000 --function="removeWrappedToken" \
-    --arguments str:${UNIVERSAL_TOKEN} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${BRIDGED_TOKENS_WRAPPER} removeWrappedToken --key-file=${ALICE} \
+    --args String:${UNIVERSAL_TOKEN} \
+    --await --sign --node ${PROXY}
 }
 
 wrapper-whitelistToken() {
     CHECK_VARIABLES BRIDGED_TOKENS_WRAPPER CHAIN_SPECIFIC_TOKEN NR_DECIMALS_CHAIN_SPECIFIC UNIVERSAL_TOKEN
 
-    mxpy contract call ${BRIDGED_TOKENS_WRAPPER} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=6000000 --function="whitelistToken" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN} ${NR_DECIMALS_CHAIN_SPECIFIC} str:${UNIVERSAL_TOKEN} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${BRIDGED_TOKENS_WRAPPER} whitelistToken --key-file=${ALICE} \
+    --args String:${CHAIN_SPECIFIC_TOKEN} --args u32:${NR_DECIMALS_CHAIN_SPECIFIC} --args String:${UNIVERSAL_TOKEN} \
+    --await --sign --node ${PROXY}
 }
 
 wrapper-blacklistToken() {
     CHECK_VARIABLES BRIDGED_TOKENS_WRAPPER CHAIN_SPECIFIC_TOKEN UNIVERSAL_TOKEN
 
-    mxpy contract call ${BRIDGED_TOKENS_WRAPPER} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=6000000 --function="blacklistToken" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${BRIDGED_TOKENS_WRAPPER} blacklistToken --key-file=${ALICE} \
+    --args String:${CHAIN_SPECIFIC_TOKEN} \
+    --await --sign --node ${PROXY}
 }
 
 wrapper-updateWrappedToken() {
     CHECK_VARIABLES BRIDGED_TOKENS_WRAPPER UNIVERSAL_TOKEN NR_DECIMALS_UNIVERSAL
 
-    mxpy contract call ${BRIDGED_TOKENS_WRAPPER} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=6000000 --function="updateWrappedToken" \
-    --arguments str:${UNIVERSAL_TOKEN} ${NR_DECIMALS_UNIVERSAL} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${BRIDGED_TOKENS_WRAPPER} updateWrappedToken --key-file=${ALICE} \
+    --args String:${UNIVERSAL_TOKEN} --args u32:${NR_DECIMALS_UNIVERSAL} \
+    --await --sign --node ${PROXY}
 }
 
 wrapper-updateWhitelistedToken() {
     CHECK_VARIABLES BRIDGED_TOKENS_WRAPPER CHAIN_SPECIFIC_TOKEN NR_DECIMALS_CHAIN_SPECIFIC
 
-    mxpy contract call ${BRIDGED_TOKENS_WRAPPER} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=6000000 --function="updateWhitelistedToken" \
-    --arguments str:${CHAIN_SPECIFIC_TOKEN} ${NR_DECIMALS_CHAIN_SPECIFIC} \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    operator sc invoke ${BRIDGED_TOKENS_WRAPPER} updateWhitelistedToken --key-file=${ALICE} \
+    --args String:${CHAIN_SPECIFIC_TOKEN} --args u32:${NR_DECIMALS_CHAIN_SPECIFIC} \
+    --await --sign --node ${PROXY}
 }
-
 
 wrapper-unpause() {
     CHECK_VARIABLES BRIDGED_TOKENS_WRAPPER
 
-    mxpy contract call ${BRIDGED_TOKENS_WRAPPER} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=5000000 --function="unpause" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    operator sc invoke ${BRIDGED_TOKENS_WRAPPER} unpause --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 wrapper-pause() {
     CHECK_VARIABLES BRIDGED_TOKENS_WRAPPER
 
-    mxpy contract call ${BRIDGED_TOKENS_WRAPPER} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=5000000 --function="pause" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    operator sc invoke ${BRIDGED_TOKENS_WRAPPER} pause --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 wrapper-pauseV2() {
     CHECK_VARIABLES BRIDGED_TOKENS_WRAPPER_v2
 
-    mxpy contract call ${BRIDGED_TOKENS_WRAPPER_v2} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=5000000 --function="pause" \
-    --send --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    operator sc invoke ${BRIDGED_TOKENS_WRAPPER_v2} pause --key-file=${ALICE} \
+    --await --sign --node ${PROXY}
 }
 
 wrapper-upgrade() {
     CHECK_VARIABLES BRIDGED_TOKENS_WRAPPER BRIDGED_TOKENS_WRAPPER_WASM
 
-    mxpy contract upgrade ${BRIDGED_TOKENS_WRAPPER} --bytecode=${BRIDGED_TOKENS_WRAPPER_WASM} --recall-nonce "${MXPY_SIGN[@]}" \
-    --gas-limit=50000000 --send \
-    --outfile="upgrade-bridged-tokens-wrapper.json" --proxy=${PROXY} --chain=${CHAIN_ID} || return 
+    operator sc upgrade ${BRIDGED_TOKENS_WRAPPER} --key-file=${ALICE} \
+    --wasm ${BRIDGED_TOKENS_WRAPPER_WASM} \
+    --await --sign --node ${PROXY}
+    
+    echo ""
+    echo "Bridged tokens wrapper upgraded successfully at address: ${BRIDGED_TOKENS_WRAPPER}"
 }

--- a/multisig/sc-config.toml
+++ b/multisig/sc-config.toml
@@ -1,4 +1,9 @@
 [settings]
+main = "multisig"
+
+# the only purpose of this config is to specify the allocator
+[contracts.multisig]
+allocator = "static64k"
 
 [[proxy]]
 path = "../multisig/src/multisig_proxy.rs"

--- a/multisig/src/kda_safe_proxy.rs
+++ b/multisig/src/kda_safe_proxy.rs
@@ -745,6 +745,54 @@ where
             .original_result()
     }
 
+    pub fn is_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, bool> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("isAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn add_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("addAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn remove_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("removeAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn admins(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, MultiValueEncoded<Env::Api, ManagedAddress<Env::Api>>> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getAdmins")
+            .original_result()
+    }
+
     pub fn pause_endpoint(
         self,
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {

--- a/multisig/src/multi_transfer_kda_proxy.rs
+++ b/multisig/src/multi_transfer_kda_proxy.rs
@@ -279,4 +279,52 @@ where
             .argument(&token_id)
             .original_result()
     }
+
+    pub fn is_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, bool> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("isAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn add_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("addAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn remove_admin<
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+    >(
+        self,
+        address: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("removeAdmin")
+            .argument(&address)
+            .original_result()
+    }
+
+    pub fn admins(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, MultiValueEncoded<Env::Api, ManagedAddress<Env::Api>>> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getAdmins")
+            .original_result()
+    }
 }

--- a/multisig/wasm/Cargo.lock
+++ b/multisig/wasm/Cargo.lock
@@ -204,6 +204,7 @@ name = "max-bridged-amount-module"
 version = "0.0.0"
 dependencies = [
  "klever-sc",
+ "klever-sc-modules",
 ]
 
 [[package]]
@@ -368,6 +369,7 @@ version = "0.0.0"
 dependencies = [
  "fee-estimator-module",
  "klever-sc",
+ "klever-sc-modules",
 ]
 
 [[package]]

--- a/multisig/wasm/src/lib.rs
+++ b/multisig/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 
-klever_sc_wasm_adapter::allocator!();
+klever_sc_wasm_adapter::allocator!(static64k);
 klever_sc_wasm_adapter::panic_handler!();
 
 klever_sc_wasm_adapter::endpoints! {


### PR DESCRIPTION
### Overview
With the changes to the bridge to run in Klever Blockchain, the snippets needed to be updated according with the CLI to interact with the chain. This PR aims to change the deploy scripts to use the operator CLI and also remove the bridge-proxy contract requirements, while the callback method isn't available.

### Changes
- Update All contracts deploy snippets to use the operator CLI
- Remove bridge proxy from the deploy workflow
- Temporary change from only_owner to only_admin endpoints 