### PR TITLE
[KLC-1693] Add set account name on bridge contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@
 **/deploy-testnet.interaction.json
 **/testnet/
 **/deploy-child-sc-spam.json
+multisig/interaction/*.wasm
+
+# prevent accidental commit of key files
+*.pem
 
 # Klever IDE
 kleverchain.workspace.json

--- a/bridged-tokens-wrapper/sc-config.toml
+++ b/bridged-tokens-wrapper/sc-config.toml
@@ -6,7 +6,7 @@ main = "bridged-tokens-wrapper"
 allocator = "static64k"
 
 [[proxy]]
-path = "../multi-transfer-esdt/src/bridged_tokens_wrapper_proxy.rs"
+path = "../multi-transfer-kda/src/bridged_tokens_wrapper_proxy.rs"
 
 [[proxy]]
 path = "../multisig/src/bridged_tokens_wrapper_proxy.rs"

--- a/bridged-tokens-wrapper/src/kda_safe_proxy.rs
+++ b/bridged-tokens-wrapper/src/kda_safe_proxy.rs
@@ -226,6 +226,19 @@ where
             .original_result()
     }
 
+    pub fn change_contract_name<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+    >(
+        self,
+        new_name: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("changeContractName")
+            .argument(&new_name)
+            .original_result()
+    }
+
     pub fn compute_total_amounts_from_index<
         Arg0: ProxyArg<u64>,
         Arg1: ProxyArg<u64>,
@@ -745,33 +758,6 @@ where
             .original_result()
     }
 
-    pub fn pause_endpoint(
-        self,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
-        self.wrapped_tx
-            .payment(NotPayable)
-            .raw_call("pause")
-            .original_result()
-    }
-
-    pub fn unpause_endpoint(
-        self,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
-        self.wrapped_tx
-            .payment(NotPayable)
-            .raw_call("unpause")
-            .original_result()
-    }
-
-    pub fn paused_status(
-        self,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, bool> {
-        self.wrapped_tx
-            .payment(NotPayable)
-            .raw_call("isPaused")
-            .original_result()
-    }
-
     pub fn is_admin<
         Arg0: ProxyArg<ManagedAddress<Env::Api>>,
     >(
@@ -817,6 +803,33 @@ where
         self.wrapped_tx
             .payment(NotPayable)
             .raw_call("getAdmins")
+            .original_result()
+    }
+
+    pub fn pause_endpoint(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("pause")
+            .original_result()
+    }
+
+    pub fn unpause_endpoint(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("unpause")
+            .original_result()
+    }
+
+    pub fn paused_status(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, bool> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("isPaused")
             .original_result()
     }
 }

--- a/bridged-tokens-wrapper/src/lib.rs
+++ b/bridged-tokens-wrapper/src/lib.rs
@@ -133,6 +133,12 @@ pub trait BridgedTokensWrapper:
         self.token_decimals_num(&chain_specific_token_id).clear();
     }
 
+    #[only_owner]
+    #[endpoint(changeContractName)]
+    fn change_contract_name(&self, new_name: ManagedBuffer) {
+        self.send().set_account_name(new_name);
+    }
+
     #[payable("*")]
     #[endpoint(depositLiquidity)]
     fn deposit_liquidity(&self) {

--- a/bridged-tokens-wrapper/wasm/src/lib.rs
+++ b/bridged-tokens-wrapper/wasm/src/lib.rs
@@ -5,8 +5,8 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           17
-// Total number of exported functions:  19
+// Endpoints:                           18
+// Total number of exported functions:  20
 
 #![no_std]
 
@@ -24,6 +24,7 @@ klever_sc_wasm_adapter::endpoints! {
         whitelistToken => whitelist_token
         updateWhitelistedToken => update_whitelisted_token
         blacklistToken => blacklist_token
+        changeContractName => change_contract_name
         depositLiquidity => deposit_liquidity
         wrapTokens => wrap_tokens
         unwrapToken => unwrap_token

--- a/common/fee-estimator-module/src/price_aggregator_proxy.rs
+++ b/common/fee-estimator-module/src/price_aggregator_proxy.rs
@@ -267,6 +267,19 @@ where
             .original_result()
     }
 
+    pub fn change_contract_name<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+    >(
+        self,
+        new_name: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("changeContractName")
+            .argument(&new_name)
+            .original_result()
+    }
+
     pub fn get_pair_decimals<
         Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
         Arg1: ProxyArg<ManagedBuffer<Env::Api>>,

--- a/kda-safe/src/kda_safe.rs
+++ b/kda-safe/src/kda_safe.rs
@@ -431,6 +431,12 @@ pub trait KDASafe:
         accumulated_transaction_fees_mapper.set(BigUint::zero());
     }
 
+    #[only_admin]
+    #[endpoint(changeContractName)]
+    fn change_contract_name(&self, new_name: ManagedBuffer) {
+        self.send().set_account_name(new_name);
+    }
+
     #[view(computeTotalAmmountsFromIndex)]
     fn compute_total_amounts_from_index(
         &self,

--- a/kda-safe/wasm/src/lib.rs
+++ b/kda-safe/wasm/src/lib.rs
@@ -5,8 +5,8 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           53
-// Total number of exported functions:  55
+// Endpoints:                           54
+// Total number of exported functions:  56
 
 #![no_std]
 
@@ -25,6 +25,7 @@ klever_sc_wasm_adapter::endpoints! {
         setBridgedTokensWrapperAddress => set_bridged_tokens_wrapper_contract_address
         withdrawRefundFeesForEthereum => withdraw_refund_fees_for_ethereum
         withdrawTransactionFees => withdraw_transaction_fees
+        changeContractName => change_contract_name
         computeTotalAmmountsFromIndex => compute_total_amounts_from_index
         getRefundAmounts => get_refund_amounts
         getTotalRefundAmounts => get_total_refund_amounts

--- a/multi-transfer-kda/src/bridged_tokens_wrapper_proxy.rs
+++ b/multi-transfer-kda/src/bridged_tokens_wrapper_proxy.rs
@@ -174,6 +174,19 @@ where
             .original_result()
     }
 
+    pub fn change_contract_name<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+    >(
+        self,
+        new_name: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("changeContractName")
+            .argument(&new_name)
+            .original_result()
+    }
+
     pub fn deposit_liquidity(
         self,
     ) -> TxTypedCall<Env, From, To, (), Gas, ()> {

--- a/multi-transfer-kda/src/kda_safe_proxy.rs
+++ b/multi-transfer-kda/src/kda_safe_proxy.rs
@@ -226,6 +226,19 @@ where
             .original_result()
     }
 
+    pub fn change_contract_name<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+    >(
+        self,
+        new_name: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("changeContractName")
+            .argument(&new_name)
+            .original_result()
+    }
+
     pub fn compute_total_amounts_from_index<
         Arg0: ProxyArg<u64>,
         Arg1: ProxyArg<u64>,
@@ -745,33 +758,6 @@ where
             .original_result()
     }
 
-    pub fn pause_endpoint(
-        self,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
-        self.wrapped_tx
-            .payment(NotPayable)
-            .raw_call("pause")
-            .original_result()
-    }
-
-    pub fn unpause_endpoint(
-        self,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
-        self.wrapped_tx
-            .payment(NotPayable)
-            .raw_call("unpause")
-            .original_result()
-    }
-
-    pub fn paused_status(
-        self,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, bool> {
-        self.wrapped_tx
-            .payment(NotPayable)
-            .raw_call("isPaused")
-            .original_result()
-    }
-
     pub fn is_admin<
         Arg0: ProxyArg<ManagedAddress<Env::Api>>,
     >(
@@ -817,6 +803,33 @@ where
         self.wrapped_tx
             .payment(NotPayable)
             .raw_call("getAdmins")
+            .original_result()
+    }
+
+    pub fn pause_endpoint(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("pause")
+            .original_result()
+    }
+
+    pub fn unpause_endpoint(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("unpause")
+            .original_result()
+    }
+
+    pub fn paused_status(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, bool> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("isPaused")
             .original_result()
     }
 }

--- a/multi-transfer-kda/src/lib.rs
+++ b/multi-transfer-kda/src/lib.rs
@@ -173,6 +173,12 @@ pub trait MultiTransferKda:
         }
     }
 
+    #[only_admin]
+    #[endpoint(changeContractName)]
+    fn change_contract_name(&self, new_name: ManagedBuffer) {
+        self.send().set_account_name(new_name);
+    }
+
     // private
 
     fn get_universal_token(&self, eth_tx: EthTransaction<Self::Api>) -> TokenIdentifier {

--- a/multi-transfer-kda/src/multi_transfer_proxy.rs
+++ b/multi-transfer-kda/src/multi_transfer_proxy.rs
@@ -145,6 +145,19 @@ where
             .original_result()
     }
 
+    pub fn change_contract_name<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+    >(
+        self,
+        new_name: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("changeContractName")
+            .argument(&new_name)
+            .original_result()
+    }
+
     pub fn wrapping_contract_address(
         self,
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ManagedAddress<Env::Api>> {

--- a/multi-transfer-kda/wasm/src/lib.rs
+++ b/multi-transfer-kda/wasm/src/lib.rs
@@ -5,8 +5,8 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           21
-// Total number of exported functions:  23
+// Endpoints:                           22
+// Total number of exported functions:  24
 
 #![no_std]
 
@@ -23,6 +23,7 @@ klever_sc_wasm_adapter::endpoints! {
         setWrappingContractAddress => set_wrapping_contract_address
         addUnprocessedRefundTxToBatch => add_unprocessed_refund_tx_to_batch
         setKdaSafeContractAddress => set_kda_safe_contract_address
+        changeContractName => change_contract_name
         getWrappingContractAddress => wrapping_contract_address
         getKdaSafeContractAddress => kda_safe_contract_address
         setMaxTxBatchSize => set_max_tx_batch_size

--- a/multisig/src/bridged_tokens_wrapper_proxy.rs
+++ b/multisig/src/bridged_tokens_wrapper_proxy.rs
@@ -174,6 +174,19 @@ where
             .original_result()
     }
 
+    pub fn change_contract_name<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+    >(
+        self,
+        new_name: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("changeContractName")
+            .argument(&new_name)
+            .original_result()
+    }
+
     pub fn deposit_liquidity(
         self,
     ) -> TxTypedCall<Env, From, To, (), Gas, ()> {

--- a/multisig/src/kda_safe_proxy.rs
+++ b/multisig/src/kda_safe_proxy.rs
@@ -226,6 +226,19 @@ where
             .original_result()
     }
 
+    pub fn change_contract_name<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+    >(
+        self,
+        new_name: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("changeContractName")
+            .argument(&new_name)
+            .original_result()
+    }
+
     pub fn compute_total_amounts_from_index<
         Arg0: ProxyArg<u64>,
         Arg1: ProxyArg<u64>,

--- a/multisig/src/multi_transfer_kda_proxy.rs
+++ b/multisig/src/multi_transfer_kda_proxy.rs
@@ -145,6 +145,19 @@ where
             .original_result()
     }
 
+    pub fn change_contract_name<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+    >(
+        self,
+        new_name: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("changeContractName")
+            .argument(&new_name)
+            .original_result()
+    }
+
     pub fn wrapping_contract_address(
         self,
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ManagedAddress<Env::Api>> {

--- a/multisig/src/multisig_proxy.rs
+++ b/multisig/src/multisig_proxy.rs
@@ -708,6 +708,19 @@ where
             .original_result()
     }
 
+    pub fn change_contract_name<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+    >(
+        self,
+        new_name: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("changeContractName")
+            .argument(&new_name)
+            .original_result()
+    }
+
     /// Minimum number of signatures needed to perform any action. 
     pub fn quorum(
         self,

--- a/multisig/src/setup.rs
+++ b/multisig/src/setup.rs
@@ -425,4 +425,34 @@ pub trait SetupModule:
             .set_wrapping_contract_address(opt_wrapping_contract_address)
             .sync_call();
     }
+
+    #[only_owner]
+    #[endpoint(changeContractName)]
+    fn change_contract_name(&self, new_name: ManagedBuffer) {
+        self.send().set_account_name(new_name);
+    }
+
+    #[only_owner]
+    #[endpoint(changeSafeContractName)]
+    fn change_safe_contract_name(&self, new_name: ManagedBuffer) {
+        let kda_safe_addr = self.kda_safe_address().get();
+
+        self.tx()
+            .to(kda_safe_addr)
+            .typed(kda_safe_proxy::KDASafeProxy)
+            .change_contract_name(new_name)
+            .sync_call();
+    }
+
+    #[only_owner]
+    #[endpoint(changeMultiTransferContractName)]
+    fn change_multi_transfer_contract_name(&self, new_name: ManagedBuffer) {
+        let multi_transfer_kda_addr = self.multi_transfer_kda_address().get();
+
+        self.tx()
+            .to(multi_transfer_kda_addr)
+            .typed(multi_transfer_kda_proxy::MultiTransferKdaProxy)
+            .change_contract_name(new_name)
+            .sync_call();
+    }
 }

--- a/multisig/wasm/src/lib.rs
+++ b/multisig/wasm/src/lib.rs
@@ -5,8 +5,8 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           72
-// Total number of exported functions:  74
+// Endpoints:                           75
+// Total number of exported functions:  77
 
 #![no_std]
 
@@ -57,6 +57,9 @@ klever_sc_wasm_adapter::endpoints! {
         multiTransferKdaSetMaxRefundTxBatchSize => multi_transfer_kda_set_max_refund_tx_batch_size
         multiTransferKdaSetMaxRefundTxBatchBlockDuration => multi_transfer_kda_set_max_refund_tx_batch_block_duration
         multiTransferKdaSetWrappingContractAddress => multi_transfer_kda_set_wrapping_contract_address
+        changeContractName => change_contract_name
+        changeSafeContractName => change_safe_contract_name
+        changeMultiTransferContractName => change_multi_transfer_contract_name
         getQuorum => quorum
         getNumBoardMembers => num_board_members
         getRequiredStakeAmount => required_stake_amount

--- a/price-aggregator/src/lib.rs
+++ b/price-aggregator/src/lib.rs
@@ -410,6 +410,12 @@ pub trait PriceAggregator:
         self.clear_submissions(&pair);
     }
 
+    #[only_owner]
+    #[endpoint(changeContractName)]
+    fn change_contract_name(&self, new_name: ManagedBuffer) {
+        self.send().set_account_name(new_name);
+    }
+
     fn check_decimals(&self, from: &ManagedBuffer, to: &ManagedBuffer, decimals: u8) {
         let configured_decimals = self.get_pair_decimals(from, to);
         require!(

--- a/price-aggregator/tests/price_aggregator_proxy.rs
+++ b/price-aggregator/tests/price_aggregator_proxy.rs
@@ -267,6 +267,19 @@ where
             .original_result()
     }
 
+    pub fn change_contract_name<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+    >(
+        self,
+        new_name: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("changeContractName")
+            .argument(&new_name)
+            .original_result()
+    }
+
     pub fn get_pair_decimals<
         Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
         Arg1: ProxyArg<ManagedBuffer<Env::Api>>,

--- a/price-aggregator/wasm/src/lib.rs
+++ b/price-aggregator/wasm/src/lib.rs
@@ -5,8 +5,8 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           21
-// Total number of exported functions:  23
+// Endpoints:                           22
+// Total number of exported functions:  24
 
 #![no_std]
 
@@ -29,6 +29,7 @@ klever_sc_wasm_adapter::endpoints! {
         setSubmissionCount => set_submission_count
         getOracles => get_oracles
         setPairDecimals => set_pair_decimals
+        changeContractName => change_contract_name
         getPairDecimals => get_pair_decimals
         submission_count => submission_count
         pause => pause_endpoint


### PR DESCRIPTION
This pull request introduces a new `changeContractName` functionality across multiple modules, enabling contract owners or administrators to update the contract name dynamically. Additionally, it includes minor adjustments to proxy paths to reflect the new functionality. 

### New Functionality: `changeContractName` Endpoint
- Added `changeContractName` endpoint to `bridged-tokens-wrapper`, allowing owners to update the contract name (`bridged-tokens-wrapper/src/lib.rs`, `bridged-tokens-wrapper/wasm/src/lib.rs`, [[1]](diffhunk://#diff-8b2b892c85b700690a92d0687a42987909e93afbcd8da8031717d84a9b615697L8-R9) [[2]](diffhunk://#diff-8b2b892c85b700690a92d0687a42987909e93afbcd8da8031717d84a9b615697R27) [[3]](diffhunk://#diff-adf4208e40f7ab8bdc954a47e42e35c09ae21f092eda75390216e9df35093982R136-R141).
- Integrated `changeContractName` into `kda-safe`, restricted to administrators (`kda-safe/src/kda_safe.rs`, `kda-safe/wasm/src/lib.rs`, [[1]](diffhunk://#diff-f328747f92ae9deb26cf50606c772d9997d808b3fa2f70cfebaa87c2c4a5c397L8-R9) [[2]](diffhunk://#diff-f328747f92ae9deb26cf50606c772d9997d808b3fa2f70cfebaa87c2c4a5c397R28) [[3]](diffhunk://#diff-b2ada5466129241fbd9e0858572d3204cc2de1ecf6823ca55a65c2da831c45f3R434-R439).
- Added `changeContractName` functionality to `multi-transfer-kda`, enabling administrators to rename the contract (`multi-transfer-kda/src/lib.rs`, `multi-transfer-kda/wasm/src/lib.rs`, [[1]](diffhunk://#diff-bb13c358370f4490241c14617bd409191ec3ba4bbe637c0475095f078bd4f78bL8-R9) [[2]](diffhunk://#diff-bb13c358370f4490241c14617bd409191ec3ba4bbe637c0475095f078bd4f78bR26) [[3]](diffhunk://#diff-7541a23823863fb998d99ae306fee36026cff16895edbf2ec5c540cf7dc39da0R176-R181).
- Extended `changeContractName` to `multisig`, including additional endpoints for changing names of related contracts (`multisig/src/setup.rs`, `multisig/wasm/src/lib.rs`, [[1]](diffhunk://#diff-6d1f0a9f0442ce627bdca81d0acff497ae3c8b3d3dd0c5cbbe377a1ad49c0855L8-R9) [[2]](diffhunk://#diff-6d1f0a9f0442ce627bdca81d0acff497ae3c8b3d3dd0c5cbbe377a1ad49c0855R60-R62) [[3]](diffhunk://#diff-6b07d274e1869a108b1d992fcd63bcdb4113ff8c72c89c80155d0bed87586506R428-R457).
- Implemented `changeContractName` in `price-aggregator`, allowing contract owners to update the name (`price-aggregator/src/lib.rs`, `price-aggregator/tests/price_aggregator_proxy.rs`, [[1]](diffhunk://#diff-0a8f10783dcfc03f5ad28881923064f6a006a1df23952ff0f32a5eaf7478bb28R270-R282) [[2]](diffhunk://#diff-80f06a68f51727cacff34605f6ba79900df2ea6bcf32e775971266ee4601766dR413-R418).

### Proxy Path Updates
- Updated proxy path in `bridged-tokens-wrapper/sc-config.toml` to reference `multi-transfer-kda` instead of `multi-transfer-esdt` (`bridged-tokens-wrapper/sc-config.toml`, [bridged-tokens-wrapper/sc-config.tomlL9-R9](diffhunk://#diff-d125fdc282137d432d3b54bdae03f0f744427e257e50da4242346eb22811bf88L9-R9)).