### PR TITLE
Change staking mechanism from KLV to KFI

### DIFF
--- a/multisig/scenarios/setup.scen.json
+++ b/multisig/scenarios/setup.scen.json
@@ -110,12 +110,18 @@
                 },
                 "address:relayer1": {
                     "nonce": "0",
-                    "balance": "1000",
+                    "balance": "0",
+                    "kda": {
+                        "str:KFI": "1000"
+                    },
                     "storage": {}
                 },
                 "address:relayer2": {
                     "nonce": "0",
-                    "balance": "1000",
+                    "balance": "0",
+                    "kda": {
+                        "str:KFI": "1000"
+                    },
                     "storage": {}
                 },
                 "address:user": {
@@ -221,8 +227,13 @@
             "tx": {
                 "from": "address:relayer1",
                 "to": "sc:multisig",
-                "value": "1000",
                 "function": "stake",
+                "kdaValue": [
+                    {
+                        "tokenIdentifier": "str:KFI",
+                        "value": "1000"
+                    }
+                ],
                 "arguments": [],
                 "gasLimit": "35,000,000",
                 "gasPrice": "0"
@@ -257,8 +268,13 @@
             "tx": {
                 "from": "address:relayer2",
                 "to": "sc:multisig",
-                "value": "1000",
                 "function": "stake",
+                "kdaValue": [
+                    {
+                        "tokenIdentifier": "str:KFI",
+                        "value": "1000"
+                    }
+                ],
                 "arguments": [],
                 "gasLimit": "35,000,000",
                 "gasPrice": "0"
@@ -286,7 +302,9 @@
                 },
                 "sc:multisig": {
                     "nonce": "*",
-                    "balance": "2000",
+                    "kda": {
+                        "str:KFI": "2000"
+                    },
                     "storage": {
                         "str:amountStaked|address:relayer1": "1000",
                         "str:amountStaked|address:relayer2": "1000",

--- a/multisig/scenarios/unstake.scen.json
+++ b/multisig/scenarios/unstake.scen.json
@@ -92,7 +92,10 @@
             "accounts": {
                 "sc:multisig": {
                     "nonce": "*",
-                    "balance": "2000",
+                    "balance": "0",
+                    "kda": {
+                        "str:KFI": "2000"
+                    },
                     "storage": {
                         "str:quorum": "1",
                         "str:user_role|u32:1": "1",
@@ -153,12 +156,18 @@
             "accounts": {
                 "address:relayer2": {
                     "nonce": "*",
-                    "balance": "1000",
+                    "balance": "0",
+                    "kda": {
+                        "str:KFI": "1000"
+                    },
                     "storage": {}
                 },
                 "sc:multisig": {
                     "nonce": "*",
-                    "balance": "1000",
+                    "balance": "0",
+                    "kda": {
+                        "str:KFI": "1000"
+                    },
                     "storage": {
                         "str:quorum": "1",
                         "str:user_role|u32:1": "1",

--- a/multisig/src/lib.rs
+++ b/multisig/src/lib.rs
@@ -149,9 +149,9 @@ pub trait Multisig:
             .sync_call();
     }
 
-    /// Board members have to stake a certain amount of KLV
+    /// Board members have to stake a certain amount of KFI
     /// before being allowed to sign actions
-    #[payable("KLV")]
+    #[payable("KFI")]
     #[endpoint]
     fn stake(&self, #[payment] payment: BigUint) {
         let caller = self.blockchain().get_caller();
@@ -184,7 +184,7 @@ pub trait Multisig:
         }
 
         self.amount_staked(&caller).set(&remaining_stake);
-        self.tx().to(ToCaller).klv(&amount).transfer();
+        self.tx().to(ToCaller).single_kda(&TokenIdentifier::from("KFI"), 0, &amount).transfer();
     }
 
     // KDA Safe SC calls
@@ -379,7 +379,7 @@ pub trait Multisig:
     fn withdraw_slashed_amount(&self) {
         let slashed_tokens_amount_mapper = self.slashed_tokens_amount();
         let slashed_amount = slashed_tokens_amount_mapper.get();
-        self.tx().to(ToCaller).klv(&slashed_amount).transfer();
+        self.tx().to(ToCaller).single_kda(&TokenIdentifier::from("KFI"), 0, &slashed_amount).transfer();
         slashed_tokens_amount_mapper.clear();
     }
 

--- a/multisig/tests/multisig_blackbox_test.rs
+++ b/multisig/tests/multisig_blackbox_test.rs
@@ -106,10 +106,10 @@ impl MultiTransferTestState {
             .nonce(1)
             .account(RELAYER1_ADDRESS)
             .nonce(1)
-            .balance(1_000u64)
+            .kda_balance(TokenIdentifier::from("KFI"),1_000u64)
             .account(RELAYER2_ADDRESS)
             .nonce(1)
-            .balance(1_000u64);
+            .kda_balance(TokenIdentifier::from("KFI"),1_000u64);
 
         let roles = vec![
             "KDARoleMint".to_string(),
@@ -359,7 +359,7 @@ impl MultiTransferTestState {
             .to(MULTISIG_ADDRESS)
             .typed(multisig_proxy::MultisigProxy)
             .stake()
-            .klv(1_000)
+            .single_kda(&TokenIdentifier::from("KFI"),0 ,&BigUint::from(1_000u64))
             .run();
 
         self.world
@@ -368,7 +368,7 @@ impl MultiTransferTestState {
             .to(MULTISIG_ADDRESS)
             .typed(multisig_proxy::MultisigProxy)
             .stake()
-            .klv(1_000)
+            .single_kda(&TokenIdentifier::from("KFI"),0 ,&BigUint::from(1_000u64))
             .run();
 
         let staked_relayers = self


### PR DESCRIPTION
This pull request updates the multisig smart contract and its related scenario and test files to migrate staking and related operations from using the KLV token to the KFI token. The changes ensure that all staking, balance tracking, and transfers now use KFI, and update the scenario and test data structures to reflect this new token standard.

**Migration from KLV to KFI for staking and balances:**

* Updated the `stake` and `withdraw_slashed_amount` endpoints in `multisig/src/lib.rs` to use KFI instead of KLV, including changing the payable attribute and transfer logic to use `single_kda` with the KFI token identifier. [[1]](diffhunk://#diff-86f4e262caddbeaa982d5955b7dad07a4fc09831d10a867bd7d34fd345054026L152-R154) [[2]](diffhunk://#diff-86f4e262caddbeaa982d5955b7dad07a4fc09831d10a867bd7d34fd345054026L187-R187) [[3]](diffhunk://#diff-86f4e262caddbeaa982d5955b7dad07a4fc09831d10a867bd7d34fd345054026L382-R382)
* Updated test logic in `multisig/tests/multisig_blackbox_test.rs` to use KFI for account balances and staking transactions, replacing `.balance` and `.klv` with `.kda_balance` and `.single_kda` for the KFI token. [[1]](diffhunk://#diff-e8dbe0bd6cc0ac200d629a0d113c77181cfce0f4879d833ee0d6192fd16ee498L109-R112) [[2]](diffhunk://#diff-e8dbe0bd6cc0ac200d629a0d113c77181cfce0f4879d833ee0d6192fd16ee498L362-R362) [[3]](diffhunk://#diff-e8dbe0bd6cc0ac200d629a0d113c77181cfce0f4879d833ee0d6192fd16ee498L371-R371)

**Scenario and account data structure updates:**

* Modified scenario files (`multisig/scenarios/setup.scen.json` and `multisig/scenarios/unstake.scen.json`) to replace top-level `balance` fields with KFI balances under a `kda` object, and updated transaction objects to use `kdaValue` with the KFI token identifier instead of `value`. [[1]](diffhunk://#diff-15adb575a6ae8246e54105c425a0dfb1f1e2907ea1b035cf03347ffce2f2c227L113-R124) [[2]](diffhunk://#diff-15adb575a6ae8246e54105c425a0dfb1f1e2907ea1b035cf03347ffce2f2c227L224-R236) [[3]](diffhunk://#diff-15adb575a6ae8246e54105c425a0dfb1f1e2907ea1b035cf03347ffce2f2c227L260-R277) [[4]](diffhunk://#diff-15adb575a6ae8246e54105c425a0dfb1f1e2907ea1b035cf03347ffce2f2c227L289-R307) [[5]](diffhunk://#diff-963e62db051db0a46c56a9dd71af6245a3564980764bf733e68a95f9638c8fc4L95-R98) [[6]](diffhunk://#diff-963e62db051db0a46c56a9dd71af6245a3564980764bf733e68a95f9638c8fc4L156-R170)

These changes ensure the multisig contract and its tests are now fully compatible with the KFI token standard and no longer use KLV.